### PR TITLE
Encode/decode URIs

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # dxApi
 
+## in develop
+
+* Adds functions to create `dx://` URIs from components
+* URL-encodes project names, paths, and file names when creating `dx://` URIs, and decodes them when parsing 
+
 ## 0.2.0 (2021-04-23)
 
 * Adds option to wait for upload to `DxApi.uploadFile`

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -59,6 +59,7 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
   private lazy val objMapper: ObjectMapper = new ObjectMapper()
   private val DownloadRetryLimit = 3
   private val UploadRetryLimit = 3
+  private val UploadWaitMillis = 1000
 
   // We are expecting string like:
   //    record-FgG51b00xF63k86F13pqFv57
@@ -919,7 +920,7 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
       .range(0, UploadRetryLimit)
       .collectFirstDefined { counter =>
         if (counter > 0) {
-          Thread.sleep(1000)
+          Thread.sleep(UploadWaitMillis * scala.math.pow(2, counter).toLong)
         }
         logger.traceLimited(s"upload file ${path.toString} (try=${counter})")
         uploadOneFile(path) match {


### PR DESCRIPTION
URL-encodes project names, paths, and file names when creating `dx://` URIs, and decodes them when parsing; Adds functions to create `dx://` URIs from components.

I also made upload* use exponentially increasing backoff