### PR TITLE
Add FileSource.relativize method

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # dxApi
 
-## in develop
+## 0.3.0 (2021-05-07)
 
 * Adds functions to create `dx://` URIs from components
 * URL-encodes project names, paths, and file names when creating `dx://` URIs, and decodes them when parsing 

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ val protocols = project
 
 lazy val dependencies =
   new {
-    val dxCommonVersion = "0.2.15-SNAPSHOT"
+    val dxCommonVersion = "0.3.1-SNAPSHOT"
     val dxApiVersion = "0.3.0-SNAPSHOT"
     val typesafeVersion = "1.3.3"
     val sprayVersion = "1.3.5"

--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## in develop
 
+* Adds `relativize` method to `AddressableFileSource`
+
+## 0.3.0 (2021-05-07)
+
 * Fixes implementations of `AddressableFileSource.folder` for cases where the file source represents a root directory
 * Adds `listing` method to `FileSource`
 * Adds `container` and `version` fields to `AddressableFileSource` 

--- a/common/src/main/scala/dx/util/FileSource.scala
+++ b/common/src/main/scala/dx/util/FileSource.scala
@@ -118,6 +118,15 @@ trait AddressableFileSource extends FileSource {
     */
   def resolve(path: String): AddressableFileSource
 
+  /**
+    * Returns the path of `fileSource` relative to this one, if this is a
+    * directory, or to the parent, if this is a file. Throws an exception
+    * if this is not an ancestor of `fileSource`.
+    * @param fileSource the child AddressableFileSource
+    * @return
+    */
+  def relativize(fileSource: AddressableFileSource): String
+
   def uri: URI = URI.create(address)
 
   override def toString: String = address
@@ -284,6 +293,14 @@ case class LocalFileSource(
       case _                       => false
     }
     LocalFileSource(newPath, encoding, newIsDirectory)(newPath.toString, newPath, logger)
+  }
+
+  override def relativize(fileSource: AddressableFileSource): String = {
+    fileSource match {
+      case fs: LocalFileSource => canonicalPath.relativize(fs.canonicalPath).toString
+      case _ =>
+        throw new Exception(s"not a LocalFileSource: ${fileSource}")
+    }
   }
 
   def checkExists(exists: Boolean): Unit = {
@@ -472,9 +489,20 @@ case class HttpFileSource(
   }
 
   override def resolve(path: String): HttpFileSource = {
-    val newUri = uri.resolve(path)
-    val isDirectory = path.endsWith("/")
-    HttpFileSource(newUri, encoding, isDirectory)(newUri.toString)
+    val newUri = if (isDirectory) {
+      uri.resolve(path)
+    } else {
+      uri.resolve(".").resolve(path)
+    }
+    HttpFileSource(newUri, encoding, path.endsWith("/"))(newUri.toString)
+  }
+
+  override def relativize(fileSource: AddressableFileSource): String = {
+    fileSource match {
+      case fs: HttpFileSource => uri.relativize(fs.uri).getPath
+      case _ =>
+        throw new Exception(s"not a HttpFileSource: ${fileSource}")
+    }
   }
 
   // https://stackoverflow.com/questions/12800588/how-to-calculate-a-file-size-from-url-in-java

--- a/common/src/main/scala/dx/util/FileSource.scala
+++ b/common/src/main/scala/dx/util/FileSource.scala
@@ -633,21 +633,56 @@ case class FileSourceResolver(protocols: Vector[FileAccessProtocol]) {
     }
   }
 
-  private[util] def getScheme(address: String): String = {
-    FileUtils.getUriScheme(address).getOrElse(FileUtils.FileScheme)
-  }
-
-  def resolve(address: String): AddressableFileNode = {
-    getProtocolForScheme(getScheme(address)).resolve(address)
-  }
-
-  def resolveDirectory(address: String): AddressableFileSource = {
-    val scheme = getScheme(address)
-    val proto = getProtocolForScheme(scheme)
-    if (!proto.supportsDirectories) {
-      throw ProtocolFeatureNotSupportedException(scheme, "directories")
+  def resolve(address: String,
+              parent: Option[AddressableFileSource] = None): AddressableFileNode = {
+    FileUtils.getUriScheme(address) match {
+      case Some(scheme) =>
+        // a full URI
+        getProtocolForScheme(scheme).resolve(address)
+      case None if parent.isDefined =>
+        // a relative path - try to resolve against the parent
+        parent.get.resolve(address) match {
+          case fn: AddressableFileNode if fn.exists =>
+            // a path relative to parent
+            fn
+          case _: LocalFileSource =>
+            // the imported file is not relative to the parent, but
+            // but LocalFileAccessProtocol may be configured to look
+            // for it in a different folder
+            fromPath(Paths.get(address))
+          case other =>
+            throw new Exception(s"Not an AddressableFileNode: ${other}")
+        }
+      case None =>
+        getProtocolForScheme(FileUtils.FileScheme).resolve(address)
     }
-    proto.resolveDirectory(address)
+  }
+
+  def resolveDirectory(address: String,
+                       parent: Option[AddressableFileSource] = None): AddressableFileSource = {
+    FileUtils.getUriScheme(address) match {
+      case Some(scheme) =>
+        val proto = getProtocolForScheme(scheme)
+        if (!proto.supportsDirectories) {
+          throw ProtocolFeatureNotSupportedException(scheme, "directories")
+        }
+        proto.resolveDirectory(address)
+      case None if parent.isDefined =>
+        parent.get.resolve(address) match {
+          case fs: AddressableFileSource if fs.exists =>
+            // a path relative to parent
+            fs
+          case _: LocalFileSource =>
+            // the imported file is not relative to the parent, but
+            // but LocalFileAccessProtocol may be configured to look
+            // for it in a different folder
+            fromPath(Paths.get(address))
+          case other =>
+            throw new Exception(s"Not an AddressableFileNode: ${other}")
+        }
+      case None =>
+        getProtocolForScheme(FileUtils.FileScheme).resolveDirectory(address)
+    }
   }
 
   def fromPath(path: Path): LocalFileSource = {
@@ -721,6 +756,10 @@ object FileSourceResolver {
         HttpFileAccessProtocol(encoding)
     )
     FileSourceResolver(protocols ++ userProtocols)
+  }
+
+  def getScheme(address: String): String = {
+    FileUtils.getUriScheme(address).getOrElse(FileUtils.FileScheme)
   }
 }
 

--- a/common/src/main/scala/dx/util/FileUtils.scala
+++ b/common/src/main/scala/dx/util/FileUtils.scala
@@ -20,7 +20,7 @@ object FileUtils {
   val FileScheme: String = "file"
   val HttpScheme: String = "http"
   val HttpsScheme: String = "https"
-  private val uriRegexp = "^(.+?)://.+".r
+  private val uriRegexp = "^(.+?):/.+".r
   // the spec states that WDL files must use UTF8 encoding
   val DefaultEncoding: Charset = Codec.UTF8.charSet
   val DefaultLineSeparator: String = "\n"

--- a/common/src/test/scala/dx/util/FileSourceTest.scala
+++ b/common/src/test/scala/dx/util/FileSourceTest.scala
@@ -11,7 +11,7 @@ class FileSourceTest extends AnyFlatSpec with Matchers {
   private val resolver = FileSourceResolver.create(userProtocols = Vector(DxProtocol))
 
   def getProtocol(uriOrPath: String): FileAccessProtocol = {
-    val scheme = resolver.getScheme(uriOrPath)
+    val scheme = FileSourceResolver.getScheme(uriOrPath)
     resolver.getProtocolForScheme(scheme)
   }
 

--- a/protocols/RELEASE_NOTES.md
+++ b/protocols/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## in develop
 
+* Implements `listing` and `relativize` methods for dx and S3 protocols
+
+## 0.2.0 (2021-05-07)
+
 * Fixes handling of `DxFolderSource` for root folders
 * Implements `container` and `version` fields for dx and S3 protocols
 


### PR DESCRIPTION
Also adds an optional `parent` argument to the `FileSourceResolver.resolve*` methods.

Both of these changes are necessary for a fix to wdlTools for handling of http imports.