### PR TITLE
Use project information when uploading

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -5,7 +5,10 @@
 * Adds `folder` attribute to job description
 * Checks that all necessary fields are available when trying to used cached object descriptions
 * Creates `DxFile` with destination project when uploading to a destination project
-
+* Modifies `DxFile.uploadDirectory` signature:
+    * Optional `filter` parameter to upload only certain files in the directory
+    * Also returns mapping of local path to `DxFile`
+    
 ## 0.4.1 (2021-06-08)
 
 * Adds warning when `findDataObjects` is called without a project

--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # dxApi
 
+## in develop
+
+* Adds `folder` attribute to job description
+
 ## 0.4.1 (2021-06-08)
 
 * Adds warning when `findDataObjects` is called without a project

--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -3,6 +3,8 @@
 ## in develop
 
 * Adds `folder` attribute to job description
+* Checks that all necessary fields are available when trying to used cached object descriptions
+* Creates `DxFile` with destination project when uploading to a destination project
 
 ## 0.4.1 (2021-06-08)
 

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -1038,7 +1038,7 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
       destination: Option[String] = None,
       recursive: Boolean = true,
       wait: Boolean = false,
-      filter: Option[Path => Boolean]
+      filter: Option[Path => Boolean] = None
   ): (Option[String], String, Map[Path, DxFile]) = {
     val visitor = UploadFileVisitor(path, destination, wait, filter)
     val maxDepth = if (recursive) Integer.MAX_VALUE else 0

--- a/api/src/main/scala/dx/api/DxJob.scala
+++ b/api/src/main/scala/dx/api/DxJob.scala
@@ -14,7 +14,8 @@ case class DxJobDescribe(id: String,
                          analysis: Option[DxAnalysis],
                          executable: Option[DxExecutable],
                          output: Option[JsValue],
-                         instanceType: Option[String])
+                         instanceType: Option[String],
+                         folder: Option[String])
     extends DxObjectDescribe
 
 case class DxJob(id: String, project: Option[DxProject] = None)(dxApi: DxApi = DxApi.get)
@@ -59,6 +60,7 @@ object DxJob {
                         None,
                         None,
                         None,
+                        None,
                         None)
         case _ =>
           throw new Exception(s"Malformed JSON ${descJs}")
@@ -87,12 +89,18 @@ object DxJob {
       case None                         => None
       case other                        => throw new Exception(s"should be an instance type ${other}")
     }
+    val folder = descJs.fields.get("folder") match {
+      case Some(JsString(folder)) => Some(folder)
+      case None                   => None
+      case other                  => throw new Exception(s"should be a folder ${other}")
+    }
     desc.copy(details = details,
               properties = props,
               parentJob = parentJob,
               analysis = analysis,
               executable = executable,
               output = output,
-              instanceType = instanceType)
+              instanceType = instanceType,
+              folder = folder)
   }
 }

--- a/api/src/main/scala/dx/api/DxObject.scala
+++ b/api/src/main/scala/dx/api/DxObject.scala
@@ -22,6 +22,8 @@ trait DxObjectDescribe {
   val details: Option[JsValue]
 
   def getCreationDate: java.util.Date = new java.util.Date(created)
+
+  def containsAll(fields: Set[Field.Value]): Boolean = ???
 }
 
 trait DxObject {
@@ -119,7 +121,10 @@ trait DxExecution extends DxObject {
   val project: Option[DxProject]
 }
 
-// DxDataObject that caches its description
+/**
+  * DxDataObject that caches its description.
+  * @tparam T type of DxObjectDescribe - must override `containsAll`
+  */
 abstract class CachingDxObject[T <: DxObjectDescribe] extends DxObject {
   private var cachedDesc: Option[T] = None
 
@@ -130,10 +135,11 @@ abstract class CachingDxObject[T <: DxObjectDescribe] extends DxObject {
   }
 
   def describe(fields: Set[Field.Value] = Set.empty): T = {
-    if (cachedDesc.isEmpty) {
+    // only call describe if there is not a cached value,
+    // or if the cached value does not contain all the
+    // required fields
+    if (cachedDesc.isEmpty || !cachedDesc.get.containsAll(fields)) {
       cachedDesc = Some(describeNoCache(fields))
-    } else {
-      // TODO: check that all `fields` are present in desc
     }
     cachedDesc.get
   }


### PR DESCRIPTION
* When uploading files, if a destination is specified, use the destination project when creating the `DxFile` object
* When describing a `CachingDxObject`, check that all the required fields are available before using a cached description
* Adds the `folder` attribute to `DxJobDescribe`
* Adds mapping of local path to `DxFile` to `uploadDirectory` return value
* Adds optional `filter` parameter to `uploadDirectory` for controlling which files to upload