### PR TITLE
Fix `prettyFormat`

### DIFF
--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## in develop
 
 * Adds optional `localizationDir` parameter to `LocalizationDisambiguator` methods for specifying the localization directory that must be used
+* Fixes `prettyFormat` function to handle case clases with public fields in the second parameter list
 
 ## 0.4.1 (2021-06-08)
 

--- a/common/src/main/scala/dx/util/package.scala
+++ b/common/src/main/scala/dx/util/package.scala
@@ -45,56 +45,61 @@ package object util {
                    callback: Option[Product => Option[String]] = None): String = {
     val indent = " " * depth * indentSize
     val fieldIndent = indent + (" " * indentSize)
-    val thisDepth = prettyFormat(_: Any, indentSize, maxElementWidth, depth, callback)
     val nextDepth = prettyFormat(_: Any, indentSize, maxElementWidth, depth + 1, callback)
     a match {
-      // Make Strings look similar to their literal form.
       case s: String =>
-        val replaceMap = Seq(
-            "\n" -> "\\n",
-            "\r" -> "\\r",
-            "\t" -> "\\t",
-            "\"" -> "\\\""
-        )
-        val buf = replaceMap.foldLeft(s) { case (acc, (c, r)) => acc.replace(c, r) }
-        s""""${buf}""""
-      // For an empty Seq just use its normal String representation.
-      case xs: Seq[_] if xs.isEmpty => xs.toString()
-      case xs: Seq[_]               =>
-        // If the Seq is not too long, pretty print on one line.
+        // make Strings look similar to their literal form
+        val builder = new StringBuilder
+        s.foreach {
+          case '\n' => builder.append("\\n")
+          case '\r' => builder.append("\\r")
+          case '\t' => builder.append("\\t")
+          case '"'  => builder.append("\\\"")
+          case c    => builder.append(c)
+        }
+        s""""${builder.toString()}""""
+      case xs: Seq[_] if xs.isEmpty =>
+        // for an empty Seq just use its normal String representation
+        xs.toString()
+      case xs: Seq[_] =>
         val resultOneLine = xs.map(nextDepth).toString()
-        if (resultOneLine.length <= maxElementWidth) return resultOneLine
-        // Otherwise, build it with newlines and proper field indents.
-        val result = xs.map(x => s"\n$fieldIndent${nextDepth(x)}").toString()
-        result.substring(0, result.length - 1) + "\n" + indent + ")"
+        if (resultOneLine.length <= maxElementWidth) {
+          // if the Seq is not too long, pretty print on one line
+          resultOneLine
+        } else {
+          // otherwise, build it with newlines and proper field indents
+          val result = xs.map(x => s"\n${fieldIndent}${nextDepth(x)}").toString()
+          s"${result.substring(0, result.length - 1)}\n${indent})"
+        }
       case Some(x) =>
-        s"Some(\n$fieldIndent${prettyFormat(x, indentSize, maxElementWidth, depth + 1, callback)}\n$indent)"
-      case None => "None"
-      // Product should cover case classes.
+        s"Some(\n${fieldIndent}${prettyFormat(x, indentSize, maxElementWidth, depth + 1, callback)}\n${indent})"
+      case None       => "None"
       case p: Product =>
-        callback.map(_(p)) match {
-          case Some(Some(s)) => s
-          case _ =>
-            val prefix = p.productPrefix
-            // We'll use reflection to get the constructor arg names and values.
-            val cls = p.getClass
-            val fields = cls.getDeclaredFields.filterNot(_.isSynthetic).map(_.getName)
-            val values = p.productIterator.toSeq
-            // If we weren't able to match up fields/values, fall back to toString.
-            if (fields.length != values.length) return p.toString
-            fields.zip(values).toList match {
-              // If there are no fields, just use the normal String representation.
-              case Nil => p.toString
-              // If there is just one field, let's just print it as a wrapper.
-              case (_, value) :: Nil => s"$prefix(${thisDepth(value)})"
-              // If there is more than one field, build up the field names and values.
-              case kvps =>
-                val prettyFields = kvps.map { case (k, v) => s"$fieldIndent$k = ${nextDepth(v)}" }
-                // If the result is not too long, pretty print on one line.
-                val resultOneLine = s"$prefix(${prettyFields.mkString(", ")})"
-                if (resultOneLine.length <= maxElementWidth) return resultOneLine
-                // Otherwise, build it with newlines and proper field indents.
-                s"$prefix(\n${prettyFields.mkString(",\n")}\n$indent)"
+        // Product includes case classes
+        // first check if the callback returns a value
+        callback.flatMap(_(p)) match {
+          case Some(s) => s
+          case _       =>
+            // Use reflection to get the constructor arg names and values.
+            // Note that this excludes any public values in the case class
+            // second parameter list (if any).
+            p.productElementNames.zip(p.productIterator).toList match {
+              case Nil =>
+                // there are no fields, just use toString
+                p.toString
+              case kvs =>
+                // there is more than one field, build up the field names and values
+                val prettyFields = kvs.map {
+                  case (k, v) => s"${fieldIndent}${k} = ${nextDepth(v)}"
+                }
+                // if the result is not too long, pretty print on one line.
+                val resultOneLine = s"${p.productPrefix}(${prettyFields.mkString(", ")})"
+                if (resultOneLine.length <= maxElementWidth) {
+                  resultOneLine
+                } else {
+                  // Otherwise, build it with newlines and proper field indents.
+                  s"${p.productPrefix}(\n${prettyFields.mkString(",\n")}\n${indent})"
+                }
             }
         }
       // If we haven't specialized this type, just use its toString.

--- a/common/src/main/scala/dx/util/package.scala
+++ b/common/src/main/scala/dx/util/package.scala
@@ -90,7 +90,7 @@ package object util {
               case kvs =>
                 // there is more than one field, build up the field names and values
                 val prettyFields = kvs.map {
-                  case (k, v) => s"${fieldIndent}${k} = ${nextDepth(v)}"
+                  case (k, v) => s"${k} = ${nextDepth(v)}"
                 }
                 // if the result is not too long, pretty print on one line.
                 val resultOneLine = s"${p.productPrefix}(${prettyFields.mkString(", ")})"
@@ -98,7 +98,7 @@ package object util {
                   resultOneLine
                 } else {
                   // Otherwise, build it with newlines and proper field indents.
-                  s"${p.productPrefix}(\n${prettyFields.mkString(",\n")}\n${indent})"
+                  s"${p.productPrefix}(\n${prettyFields.map(f => s"${fieldIndent}${f}").mkString(",\n")}\n${indent})"
                 }
             }
         }

--- a/common/src/test/scala/dx/util/PackageTest.scala
+++ b/common/src/test/scala/dx/util/PackageTest.scala
@@ -3,6 +3,9 @@ package dx.util
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+case class Foo(s1: String, s2: String)(val hidden: Int = 1)
+case class Bar(foo: Foo)
+
 class PackageTest extends AnyFlatSpec with Matchers {
   it should "generate a brief exception message" in {
     try {
@@ -16,5 +19,16 @@ class PackageTest extends AnyFlatSpec with Matchers {
       case ex: Exception =>
         exceptionToString(ex, brief = true) shouldBe "exception 2\n  caused by: exception 1"
     }
+  }
+
+  it should "pretty format a case class" in {
+    val bar = Bar(Foo("value1", "value2")())
+    prettyFormat(bar, maxElementWidth = 4) shouldBe
+      """Bar(
+        |  foo = Foo(
+        |    s1 = "value1",
+        |    s2 = "value2"
+        |  )
+        |)""".stripMargin
   }
 }

--- a/common/src/test/scala/dx/util/PackageTest.scala
+++ b/common/src/test/scala/dx/util/PackageTest.scala
@@ -4,7 +4,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 case class Foo(s1: String, s2: String)(val hidden: Int = 1)
-case class Bar(foo: Foo)
+case class Bar(s3: String)
+case class Baz(foo: Foo, bar: Bar)
 
 class PackageTest extends AnyFlatSpec with Matchers {
   it should "generate a brief exception message" in {
@@ -22,13 +23,14 @@ class PackageTest extends AnyFlatSpec with Matchers {
   }
 
   it should "pretty format a case class" in {
-    val bar = Bar(Foo("value1", "value2")())
-    prettyFormat(bar, maxElementWidth = 4) shouldBe
-      """Bar(
+    val bar = Baz(Foo("value1", "value2")(), bar = Bar("value3"))
+    prettyFormat(bar, maxElementWidth = 26) shouldBe
+      """Baz(
         |  foo = Foo(
         |    s1 = "value1",
         |    s2 = "value2"
-        |  )
+        |  ),
+        |  bar = Bar(s3 = "value3")
         |)""".stripMargin
   }
 }


### PR DESCRIPTION
In `wdlTools`, after changing the `loc` field to be in the second parameter list in all the AST classes, the `printTree` command stopped having nicely formatted output. This fix to `prettyFormat` now handles case classes with a public field in the second parameter list.