### PR TITLE
Improve `FileSource.listing`

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -8,7 +8,8 @@
 * Modifies `DxFile.uploadDirectory` signature:
     * Optional `filter` parameter to upload only certain files in the directory
     * Also returns mapping of local path to `DxFile`
-    
+* Caches projects by ID as well as by name for later reuse
+
 ## 0.4.1 (2021-06-08)
 
 * Adds warning when `findDataObjects` is called without a project

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -1011,7 +1011,7 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
     }
 
     override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-      if (filter.forall(f => f(file))) {
+      if (!attrs.isDirectory && filter.forall(f => f(file))) {
         val fileRelPath = sourceDir.relativize(file)
         val fileDestPath = s"${folder}${fileRelPath}"
         val fileDest = projectId.map(p => s"${p}:${fileDestPath}").getOrElse(fileDestPath)
@@ -1041,7 +1041,7 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
       filter: Option[Path => Boolean] = None
   ): (Option[String], String, Map[Path, DxFile]) = {
     val visitor = UploadFileVisitor(path, destination, wait, filter)
-    val maxDepth = if (recursive) Integer.MAX_VALUE else 0
+    val maxDepth = if (recursive) Integer.MAX_VALUE else 1
     Files.walkFileTree(path, javautil.EnumSet.noneOf(classOf[FileVisitOption]), maxDepth, visitor)
     visitor.result
   }

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -123,13 +123,13 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
   private var projectDict: Map[String, DxProject] = Map.empty
 
   def resolveProject(projName: String): DxProject = {
+    if (projectDict.contains(projName)) {
+      return projectDict(projName)
+    }
+
     if (projName.startsWith("project-")) {
       // A project ID
       return project(projName)
-    }
-
-    if (projectDict.contains(projName)) {
-      return projectDict(projName)
     }
 
     // A project name, resolve it
@@ -161,7 +161,7 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
             s"Bad response from SystemFindProject API call ${responseJs.prettyPrint}"
         )
     }
-    projectDict += (projName -> dxProject)
+    projectDict ++= Map(projName -> dxProject, dxProject.id -> dxProject)
     dxProject
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,8 +92,8 @@ val protocols = project
 
 lazy val dependencies =
   new {
-    val dxCommonVersion = "0.4.1-SNAPSHOT"
-    val dxApiVersion = "0.4.1-SNAPSHOT"
+    val dxCommonVersion = "0.4.2-SNAPSHOT"
+    val dxApiVersion = "0.4.2-SNAPSHOT"
     val typesafeVersion = "1.3.3"
     val sprayVersion = "1.3.5"
     val scalatestVersion = "3.1.1"

--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Adds optional `localizationDir` parameter to `LocalizationDisambiguator` methods for specifying the localization directory that must be used
 * Fixes `prettyFormat` function to handle case clases with public fields in the second parameter list
+* Adds `recurse` parameter (default=`false`) to `FileSource.listing`
 
 ## 0.4.1 (2021-06-08)
 

--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 * Adds optional `localizationDir` parameter to `LocalizationDisambiguator` methods for specifying the localization directory that must be used
 * Fixes `prettyFormat` function to handle case clases with public fields in the second parameter list
-* Adds `recurse` parameter (default=`false`) to `FileSource.listing`
+* Adds `recursive` parameter (default=`false`) to `FileSource.listing`
 
 ## 0.4.1 (2021-06-08)
 

--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 * Adds optional `localizationDir` parameter to `LocalizationDisambiguator` methods for specifying the localization directory that must be used
 * Fixes `prettyFormat` function to handle case clases with public fields in the second parameter list
 * Adds `recursive` parameter (default=`false`) to `FileSource.listing`
+* Caches parent `LocalFileSource` when resolving children
 
 ## 0.4.1 (2021-06-08)
 

--- a/common/src/main/scala/dx/util/FileSource.scala
+++ b/common/src/main/scala/dx/util/FileSource.scala
@@ -85,7 +85,7 @@ trait FileSource {
   /**
     * Whether `listing` may be called.
     */
-  def isListable: Boolean = false
+  def isListable: Boolean = isDirectory
 
   /**
     * If `isDirectory=true` and `isListable=true`, returns a Vector of
@@ -398,8 +398,6 @@ case class LocalFileSource(
     }
   }
 
-  override def isListable: Boolean = isDirectory
-
   private class ListingFileVisitor extends SimpleFileVisitor[Path] {
     private var dirs = Map.empty[Path, Vector[Path]]
 
@@ -679,6 +677,8 @@ case class HttpFileSource(
       localizeToFile(file)
     }
   }
+
+  override def isListable: Boolean = false
 }
 
 case class HttpFileAccessProtocol(encoding: Charset = FileUtils.DefaultEncoding)

--- a/common/src/main/scala/dx/util/FileSource.scala
+++ b/common/src/main/scala/dx/util/FileSource.scala
@@ -303,7 +303,7 @@ case class LocalFileSource(
     Files.exists(canonicalPath)
   }
 
-  override def getParent: Option[LocalFileSource] = {
+  override lazy val getParent: Option[LocalFileSource] = {
     cachedParent.orElse(Option(canonicalPath.getParent).map { parent =>
       LocalFileSource(parent, encoding, isDirectory = true)(parent.toString,
                                                             parent,

--- a/common/src/test/scala/dx/util/FileSourceTest.scala
+++ b/common/src/test/scala/dx/util/FileSourceTest.scala
@@ -3,6 +3,9 @@ package dx.util
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.io.FileOutputStream
+import java.nio.file.{Files, Path}
+
 class FileSourceTest extends AnyFlatSpec with Matchers {
   case object DxProtocol extends FileAccessProtocol {
     val schemes = Vector("dx")
@@ -52,5 +55,60 @@ class FileSourceTest extends AnyFlatSpec with Matchers {
     d.relativize(f1) shouldBe "blorf.txt"
     d.relativize(f2) shouldBe "bork/blorf.txt"
     f1.relativize(f2) shouldBe "bork/blorf.txt"
+  }
+
+  private def touch(path: Path): Unit = {
+    new FileOutputStream(path.toFile).close()
+  }
+
+  it should "list a local directory" in {
+    val dir = Files.createTempDirectory("temp").toRealPath()
+    dir.toFile.deleteOnExit()
+    val foo = dir.resolve("foo.txt")
+    touch(foo)
+    val bar = dir.resolve("bar")
+    FileUtils.createDirectories(bar)
+    val baz = bar.resolve("baz.txt")
+    touch(baz)
+    val d = resolver.fromPath(dir)
+    val shallowListing = d.listing()
+    val deepListing = d.listing(true)
+    // make change to subdirectory after generating listings
+    val blorf = bar.resolve("blorf.txt")
+    touch(blorf)
+
+    // shallow listing should reflect changes to subdirectories
+    shallowListing.size shouldBe 2
+    val (shallowDirs, shallowFiles) = shallowListing.partition(_.isDirectory)
+    shallowFiles.collect {
+      case fs: LocalFileSource => fs.canonicalPath
+    } shouldBe Vector(foo)
+    shallowDirs.size shouldBe 1
+    shallowDirs.collect {
+      case fs: LocalFileSource => fs.canonicalPath
+    } shouldBe Vector(bar)
+    shallowDirs.head
+      .listing()
+      .collect {
+        case fs: LocalFileSource => fs.canonicalPath
+      }
+      .toSet shouldBe Set(baz, blorf)
+
+    // deep listing should not reflect changes to subdirectories
+    deepListing.size shouldBe 2
+    val (deepDirs, deepFiles) = deepListing.partition(_.isDirectory)
+    deepFiles.collect {
+      case fs: LocalFileSource => fs.canonicalPath
+    } shouldBe Vector(foo)
+    deepDirs.size shouldBe 1
+    deepDirs.collect {
+      case fs: LocalFileSource => fs.canonicalPath
+    } shouldBe Vector(bar)
+    deepDirs.head
+      .listing()
+      .collect {
+        case fs: LocalFileSource => fs.canonicalPath
+      }
+      .toSet shouldBe Set(baz)
   }
 }

--- a/common/src/test/scala/dx/util/LocalizationDisambiguatorTest.scala
+++ b/common/src/test/scala/dx/util/LocalizationDisambiguatorTest.scala
@@ -12,9 +12,9 @@ class LocalizationDisambiguatorTest extends AnyFlatSpec with Matchers {
     val disambiguator = SafeLocalizationDisambiguator(root, createDirs = false)
     val fileResolver = FileSourceResolver.get
     val p1 = Paths.get("/foo/bar.txt")
-    val f1 = disambiguator.getLocalPath(fileResolver.fromPath(p1))
+    val f1 = disambiguator.getLocalPath(fileResolver.fromFile(p1))
     val p2 = Paths.get("/baz/bar.txt")
-    val f2 = disambiguator.getLocalPath(fileResolver.fromPath(p2))
+    val f2 = disambiguator.getLocalPath(fileResolver.fromFile(p2))
     f1 should not equal f2
   }
 
@@ -23,10 +23,10 @@ class LocalizationDisambiguatorTest extends AnyFlatSpec with Matchers {
     root.toFile.deleteOnExit()
     val disambiguator = SafeLocalizationDisambiguator(root, createDirs = false)
     val fileResolver = FileSourceResolver.get
-    val fs1 = fileResolver.fromPath(Paths.get("/foo/bar.txt"))
-    val fs2 = fileResolver.fromPath(Paths.get("/baz/bar.txt"))
-    val fs3 = fileResolver.fromPath(Paths.get("/a/b.txt"))
-    val fs4 = fileResolver.fromPath(Paths.get("/c/d.txt"))
+    val fs1 = fileResolver.fromFile(Paths.get("/foo/bar.txt"))
+    val fs2 = fileResolver.fromFile(Paths.get("/baz/bar.txt"))
+    val fs3 = fileResolver.fromFile(Paths.get("/a/b.txt"))
+    val fs4 = fileResolver.fromFile(Paths.get("/c/d.txt"))
     val localPaths = disambiguator.getLocalPaths(Vector(fs1, fs2, fs3, fs4))
     localPaths(fs1) should not equal localPaths(fs2)
     localPaths(fs1).getParent should not equal localPaths(fs3).getParent
@@ -39,9 +39,9 @@ class LocalizationDisambiguatorTest extends AnyFlatSpec with Matchers {
     val disambiguator = SafeLocalizationDisambiguator(root, createDirs = false)
     val fileResolver = FileSourceResolver.get
     val p1 = Paths.get("/foo/bar.txt")
-    val f1 = disambiguator.getLocalPath(fileResolver.fromPath(p1))
+    val f1 = disambiguator.getLocalPath(fileResolver.fromFile(p1))
     val p2 = Paths.get("/foo/baz.txt")
-    val f2 = disambiguator.getLocalPath(fileResolver.fromPath(p2))
+    val f2 = disambiguator.getLocalPath(fileResolver.fromFile(p2))
     f1.getParent shouldBe f2.getParent
   }
 
@@ -69,8 +69,8 @@ class LocalizationDisambiguatorTest extends AnyFlatSpec with Matchers {
     root.toFile.deleteOnExit()
     val disambiguator = SafeLocalizationDisambiguator(root, createDirs = false)
     val fileResolver = FileSourceResolver.get
-    val fs1 = fileResolver.fromPath(Paths.get("/foo/bar.txt"))
-    val fs2 = fileResolver.fromPath(Paths.get("/baz/bar.txt"))
+    val fs1 = fileResolver.fromFile(Paths.get("/foo/bar.txt"))
+    val fs2 = fileResolver.fromFile(Paths.get("/baz/bar.txt"))
     val defaultDir = root.resolve("default")
     disambiguator.getLocalPath(fs1, Some(defaultDir))
     assertThrows[Exception] {

--- a/protocols/RELEASE_NOTES.md
+++ b/protocols/RELEASE_NOTES.md
@@ -2,7 +2,8 @@
 
 ## in develop
 
-* Exposes target folder in `DxFolderSource`
+* Exposes dx folder in `DxFolderSource`
+* Implements recursive listing in `S3FileAccessProtocol` and `DxFileAccessProtocol`
 
 ## 0.3.1 (2021-06-08)
 

--- a/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
+++ b/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
@@ -204,8 +204,6 @@ case class DxFolderSource(dxProject: DxProject, dxFolder: String)(
     }
   }
 
-  override val isListable: Boolean = true
-
   override def listing(recursive: Boolean = false): Vector[FileSource] = {
     cachedListing.getOrElse {
       if (recursive) {

--- a/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
+++ b/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
@@ -170,10 +170,8 @@ case class DxFolderSource(dxProject: DxProject, target: String)(
   }
 
   private lazy val deepListing: Vector[(DxFile, Path)] = {
-    val results =
-      DxFindDataObjects(protocol.dxApi)
-        .apply(Some(dxProject), Some(target), recurse = true, Some("file"))
-    val targetPath = Paths.get(target)
+    val results = DxFindDataObjects(protocol.dxApi)
+      .apply(Some(dxProject), Some(target), recurse = true, Some("file"))
     results.map {
       case (f: DxFile, _) =>
         val relPath = targetPath.relativize(Paths.get(f.describe().folder))
@@ -189,6 +187,8 @@ case class DxFolderSource(dxProject: DxProject, target: String)(
         protocol.dxApi.downloadFile(path, dxFile, overwrite = true)
     }
   }
+
+  override val isListable: Boolean = true
 
   override def listing: Vector[FileSource] = {
     val filesByFolder = deepListing.groupBy {

--- a/protocols/src/main/scala/dx/util/protocols/S3FileAccessProtocol.scala
+++ b/protocols/src/main/scala/dx/util/protocols/S3FileAccessProtocol.scala
@@ -181,8 +181,6 @@ case class S3FolderSource(override val address: String, bucketName: String, pref
     }
   }
 
-  override val isListable: Boolean = true
-
   override def listing(recursive: Boolean = false): Vector[FileSource] = {
     val s3Objs = listPrefix
     if (s3Objs.isEmpty) {

--- a/protocols/src/main/scala/dx/util/protocols/S3FileAccessProtocol.scala
+++ b/protocols/src/main/scala/dx/util/protocols/S3FileAccessProtocol.scala
@@ -175,6 +175,8 @@ case class S3FolderSource(override val address: String, bucketName: String, pref
     }
   }
 
+  override val isListable: Boolean = true
+
   override def listing: Vector[FileSource] = {
     val sourcePath = Paths.get(prefix)
     val relPaths = listPrefix.map(s3obj => sourcePath.relativize(Paths.get(s3obj.key())) -> s3obj)

--- a/protocols/src/main/scala/dx/util/protocols/S3FileAccessProtocol.scala
+++ b/protocols/src/main/scala/dx/util/protocols/S3FileAccessProtocol.scala
@@ -35,7 +35,7 @@ case class S3FileSource(
     override val address: String,
     bucketName: String,
     objectKey: String
-)(protocol: S3FileAccessProtocol)
+)(protocol: S3FileAccessProtocol, private val cachedParent: Option[S3FolderSource] = None)
     extends AbstractAddressableFileNode(address, protocol.encoding) {
 
   private lazy val request: GetObjectRequest =
@@ -63,13 +63,15 @@ case class S3FileSource(
     }
   }
 
-  override def getParent: Option[S3FolderSource] = {
-    if (folder == "") {
-      val newUri = s"s3://${bucketName}/"
-      Some(S3FolderSource(newUri, bucketName, "/")(protocol))
-    } else {
-      val newUri = s"s3://${bucketName}/${folder}"
-      Some(S3FolderSource(newUri, bucketName, folder)(protocol))
+  override lazy val getParent: Option[S3FolderSource] = {
+    cachedParent.orElse {
+      if (folder == "") {
+        val newUri = s"s3://${bucketName}/"
+        Some(S3FolderSource(newUri, bucketName, "/")(protocol))
+      } else {
+        val newUri = s"s3://${bucketName}/${folder}"
+        Some(S3FolderSource(newUri, bucketName, folder)(protocol))
+      }
     }
   }
 
@@ -97,7 +99,9 @@ case class S3FileSource(
 }
 
 case class S3FolderSource(override val address: String, bucketName: String, prefix: String)(
-    protocol: S3FileAccessProtocol
+    protocol: S3FileAccessProtocol,
+    private val cachedParent: Option[S3FolderSource] = None,
+    private var cachedListing: Option[Vector[FileSource]] = None
 ) extends AddressableFileSource {
   private lazy val prefixPath: Path = Paths.get(prefix)
 
@@ -133,12 +137,14 @@ case class S3FolderSource(override val address: String, bucketName: String, pref
     }
   }
 
-  override def getParent: Option[S3FolderSource] = {
-    if (folder == "") {
-      None
-    } else {
-      val newUri = s"s3://${bucketName}/${folder}"
-      Some(S3FolderSource(newUri, bucketName, folder)(protocol))
+  override lazy val getParent: Option[S3FolderSource] = {
+    cachedParent.orElse {
+      if (folder == "") {
+        None
+      } else {
+        val newUri = s"s3://${bucketName}/${folder}"
+        Some(S3FolderSource(newUri, bucketName, folder)(protocol))
+      }
     }
   }
 
@@ -146,9 +152,9 @@ case class S3FolderSource(override val address: String, bucketName: String, pref
     val objectKey = s"${folder}${path}"
     val newUri = s"s3://${bucketName}/${objectKey}"
     if (path.endsWith("/")) {
-      S3FolderSource(newUri, bucketName, objectKey)(protocol)
+      S3FolderSource(newUri, bucketName, objectKey)(protocol, Some(this))
     } else {
-      S3FileSource(newUri, bucketName, objectKey)(protocol)
+      S3FileSource(newUri, bucketName, objectKey)(protocol, Some(this))
     }
   }
 
@@ -177,23 +183,91 @@ case class S3FolderSource(override val address: String, bucketName: String, pref
 
   override val isListable: Boolean = true
 
-  override def listing: Vector[FileSource] = {
-    val sourcePath = Paths.get(prefix)
-    val relPaths = listPrefix.map(s3obj => sourcePath.relativize(Paths.get(s3obj.key())) -> s3obj)
-    val files = relPaths.collect {
-      case (relPath, s3Obj) if relPath.getNameCount == 1 =>
-        S3FileSource(s"s3://${bucketName}/${s3Obj.key()}", bucketName, s3Obj.key())(protocol)
+  override def listing(recursive: Boolean = false): Vector[FileSource] = {
+    val s3Objs = listPrefix
+    if (s3Objs.isEmpty) {
+      return Vector.empty
     }
-    val folders = relPaths
-      .collect {
-        case (relPath, _) if relPath.getNameCount == 2 =>
-          sourcePath.resolve(relPath.getParent).toString
+
+    if (recursive) {
+      // add all missing parent dirs
+      def addDirs(
+          path: Option[Path],
+          dirs: Map[Option[Path], (Set[Path], Set[(Path, S3Object)])]
+      ): Map[Option[Path], (Set[Path], Set[(Path, S3Object)])] = {
+        if (dirs.contains(path)) {
+          dirs
+        } else {
+          val parent = path.flatMap(p => Option(p.getParent))
+          val newDirs = if (dirs.contains(parent)) {
+            dirs
+          } else {
+            addDirs(parent, dirs)
+          }
+          val (subdirs, files) = newDirs(parent)
+          newDirs ++ Map(
+              parent -> (subdirs + path.get, files),
+              path -> (Set.empty[Path], Set.empty[(Path, S3Object)])
+          )
+        }
       }
-      .toSet
-      .map { folder: String =>
-        S3FolderSource(s"s3://${bucketName}/${folder}", bucketName, folder)(protocol)
+
+      val dirs =
+        s3Objs.foldLeft(Map(Option.empty[Path] -> (Set.empty[Path], Set.empty[(Path, S3Object)]))) {
+          case (dirs, s3Obj) =>
+            val path = Paths.get(s3Obj.key())
+            val parent = Option(path.getParent)
+            val newDirs = addDirs(parent, dirs)
+            val (subdirs, files) = newDirs(parent)
+            newDirs + (parent -> (subdirs, files + ((path, s3Obj))))
+        }
+
+      def buildListing(parent: Option[Path], parentSource: S3FolderSource): Vector[FileSource] = {
+        val (subdirs, files) = dirs(parent)
+        val fileSources = files.toVector.map {
+          case (file, s3Obj) =>
+            S3FileSource(s"s3://${bucketName}/${file.toString}", bucketName, s3Obj.key())(
+                protocol,
+                Some(parentSource)
+            )
+        }
+        val folderSources = subdirs.toVector.map { dir =>
+          val folder =
+            S3FolderSource(s"s3://${bucketName}/${dir.toString}", bucketName, dir.toString)(
+                protocol,
+                Some(parentSource)
+            )
+          folder.cachedListing = Some(buildListing(Some(dir), folder))
+          folder
+        }
+        fileSources ++ folderSources
       }
-    files ++ folders.toVector
+
+      buildListing(None, this)
+    } else {
+      val sourcePath = Paths.get(prefix)
+      val (files, folders) =
+        s3Objs.foldLeft(Vector.empty[S3FileSource], Map.empty[Path, S3FolderSource]) {
+          case ((files, folders), s3Obj) =>
+            val relPath = sourcePath.relativize(Paths.get(s3Obj.key()))
+            if (relPath.getNameCount == 1) {
+              (files :+ S3FileSource(s"s3://${bucketName}/${s3Obj.key()}", bucketName, s3Obj.key())(
+                   protocol,
+                   Some(this)
+               ),
+               folders)
+            } else if (relPath.getNameCount == 2 && !folders.contains(relPath.getParent)) {
+              val folder = sourcePath.resolve(relPath.getParent).toString
+              (files,
+               folders + (relPath.getParent -> S3FolderSource(s"s3://${bucketName}/${folder}",
+                                                              bucketName,
+                                                              folder)(protocol, Some(this))))
+            } else {
+              (files, folders)
+            }
+        }
+      files ++ folders.values.toVector
+    }
   }
 }
 

--- a/protocols/src/test/scala/dx/util/protocols/DxTest.scala
+++ b/protocols/src/test/scala/dx/util/protocols/DxTest.scala
@@ -1,0 +1,84 @@
+package dx.util.protocols
+
+import dx.api.{DxApi, DxProject}
+import dx.util.Assumptions.isLoggedIn
+import dx.util.Logger
+import dx.util.Tags.ApiTest
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DxTest extends AnyFlatSpec with Matchers {
+  assume(isLoggedIn)
+  private val logger = Logger.Quiet
+  private val dxApi: DxApi = DxApi()(logger)
+  private val proto = DxFileAccessProtocol(dxApi)
+  private val testProject = "dxCompiler_playground"
+  private lazy val dxTestProject: DxProject = {
+    try {
+      dxApi.resolveProject(testProject)
+    } catch {
+      case _: Exception =>
+        throw new Exception(
+            s"""|Could not find project ${testProject}, you probably need to be logged into
+                |the platform on staging.""".stripMargin
+        )
+    }
+  }
+  private val testFileName = "/test_data/fileA"
+  private val testFileId = "file-FGqFGBQ0ffPPkYP19gBvFkZy"
+  private val testFolder = "/test_data/2/"
+
+  it should "resolve a file by ID" taggedAs ApiTest in {
+    val f1 = proto.resolve(s"dx://${dxTestProject.id}:${testFileName}")
+    val f2 = proto.resolve(s"dx://${dxTestProject.id}:${testFileId}")
+    f1.name shouldBe "fileA"
+    f1.folder shouldBe "/test_data"
+    f1.exists shouldBe true
+    f1.isDirectory shouldBe false
+    f1.size shouldBe 42
+    f1.dxFile.id shouldBe testFileId
+    f2.name shouldBe "fileA"
+    f2.folder shouldBe "/test_data"
+    f2.exists shouldBe true
+    f2.isDirectory shouldBe false
+    f2.size shouldBe 42
+  }
+
+  it should "resolve a folder" taggedAs ApiTest in {
+    val d = proto.resolveDirectory(s"dx://${dxTestProject.id}:${testFolder}")
+    d.folder shouldBe "/test_data"
+    d.name shouldBe "2"
+    d.isDirectory shouldBe true
+    d.exists shouldBe true
+  }
+
+  it should "list a folder" taggedAs ApiTest in {
+    val d = proto.resolveDirectory(s"dx://${dxTestProject.id}:${testFolder}")
+    // shallow listing
+    val shallowListing = d.listing()
+    val (shallowFolders, shallowFiles) = shallowListing.partition(_.isDirectory)
+    shallowFolders.size shouldBe 1
+    shallowFolders.head.name shouldBe "subdir"
+    shallowFiles.size shouldBe 1
+    shallowFiles.head.name shouldBe "fileC"
+    val deepListing = d.listing(recursive = true)
+    val (deepFolders, deepFiles) = deepListing.partition(_.isDirectory)
+    deepFolders.size shouldBe 1
+    deepFolders.head.name shouldBe "subdir"
+    deepFiles.size shouldBe 1
+    deepFiles.head.name shouldBe "fileC"
+    // upload file to see if change is reflected in listing
+    val testFile =
+      dxApi.uploadString("test", s"${dxTestProject.id}:/test_data/2/subdir/test", wait = true)
+    try {
+      val shallowSubdirListing = shallowFolders.head.listing()
+      shallowSubdirListing.size shouldBe 2
+      shallowSubdirListing.map(_.name).toSet shouldBe Set("fileA", "test")
+      val deepSubdirListing = deepFolders.head.listing()
+      deepSubdirListing.size shouldBe 1
+      deepSubdirListing.head.name shouldBe "fileA"
+    } finally {
+      dxTestProject.removeObjects(Vector(testFile))
+    }
+  }
+}

--- a/protocols/src/test/scala/dx/util/protocols/DxTest.scala
+++ b/protocols/src/test/scala/dx/util/protocols/DxTest.scala
@@ -59,24 +59,44 @@ class DxTest extends AnyFlatSpec with Matchers {
     val (shallowFolders, shallowFiles) = shallowListing.partition(_.isDirectory)
     shallowFolders.size shouldBe 1
     shallowFolders.head.name shouldBe "subdir"
+    shallowFolders.head match {
+      case file: DxFolderSource => file.getParent shouldBe Some(d)
+    }
     shallowFiles.size shouldBe 1
     shallowFiles.head.name shouldBe "fileC"
+    shallowFiles.head match {
+      case file: DxFileSource => file.getParent shouldBe Some(d)
+    }
     val deepListing = d.listing(recursive = true)
     val (deepFolders, deepFiles) = deepListing.partition(_.isDirectory)
     deepFolders.size shouldBe 1
     deepFolders.head.name shouldBe "subdir"
+    deepFolders.head match {
+      case file: DxFolderSource => file.getParent shouldBe Some(d)
+    }
     deepFiles.size shouldBe 1
     deepFiles.head.name shouldBe "fileC"
+    deepFiles.head match {
+      case file: DxFileSource => file.getParent shouldBe Some(d)
+    }
     // upload file to see if change is reflected in listing
     val testFile =
       dxApi.uploadString("test", s"${dxTestProject.id}:/test_data/2/subdir/test", wait = true)
     try {
-      val shallowSubdirListing = shallowFolders.head.listing()
+      val shallowFolder = shallowFolders.head
+      val shallowSubdirListing = shallowFolder.listing()
       shallowSubdirListing.size shouldBe 2
       shallowSubdirListing.map(_.name).toSet shouldBe Set("fileA", "test")
-      val deepSubdirListing = deepFolders.head.listing()
+      shallowSubdirListing.foreach {
+        case file: DxFileSource => file.getParent shouldBe Some(shallowFolder)
+      }
+      val deepFolder = deepFolders.head
+      val deepSubdirListing = deepFolder.listing()
       deepSubdirListing.size shouldBe 1
       deepSubdirListing.head.name shouldBe "fileA"
+      deepSubdirListing.head match {
+        case file: DxFileSource => file.getParent shouldBe Some(deepFolder)
+      }
     } finally {
       dxTestProject.removeObjects(Vector(testFile))
     }


### PR DESCRIPTION
* Adds `recursive` parameter to `FileSource.listing` method.
* Defines behavior of `FileSource.listing` with respect to changes in the source folder.
* Adds caching of parent folder to local, dx, and S3 file sources
* Implements recursive listing in local, dx, and S3 file sources
* Adds `FileSource.isListable` method