### PR TITLE
Use workspace container for searching/resolving

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -5,6 +5,10 @@
 * Adds option to `DxApi.describeFilesBulk` to search first in the workspace container
 * `DxApi.resolveDataObject` now searches in the current workspace and/or project if the project is not specified explicitly
 
+## 0.5.2 (2021-06-29)
+
+* Fixes `DxApi.getWorkingDir`
+
 ## 0.5.1 (2021-06-28)
 
 * Normalizes any object/folder paths

--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -2,7 +2,8 @@
 
 ## in develop
 
-* Trace logs the API request to `findDataObjects` when called without a project
+* Adds option to `DxApi.describeFilesBulk` to search first in the workspace container
+* `DxApi.resolveDataObject` now searches in the current workspace and/or project if the project is not specified explicitly
 
 ## 0.5.1 (2021-06-28)
 

--- a/api/src/main/java/com/dnanexus/DXEnvironment.java
+++ b/api/src/main/java/com/dnanexus/DXEnvironment.java
@@ -504,6 +504,10 @@ public class DXEnvironment {
         return projectContextId;
     }
 
+    public String getWorkspace() {
+        return workspaceId;
+    }
+
     /**
      * Returns the security context JSON.
      *

--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # dxCommon
 
+## 0.5.2 (2021-06-29)
+
+* No longer uses `--quiet` option with `docker pull` in `DockerUtils.pullImage`
+
 ## 0.5.1 (2021-06-28)
 
 * Adds `FileUtils.normalizePath`


### PR DESCRIPTION
In the context of a job/analysis, the workspace container has all the input files cloned into it. This PR:

* Updates `DxApi.resolveDataObject` to search in the workspace container if a project is not specified
* Updates `DxApi.describeFilesBulk` to optionally search in the workspace container first before searching in the source projects.
* Adds a `validate` option to `DxApi.describeFilesBulk` that checks that the query returned exactly one result for each file.