### PR TITLE
Better handling insufficient permissions when requesting instance type price list

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Adds option to `DxApi.describeFilesBulk` to search first in the workspace container
 * `DxApi.resolveDataObject` now searches in the current workspace and/or project if the project is not specified explicitly
+* Better handles insufficient permissions when requesting instance type price list
 
 ## 0.5.2 (2021-06-29)
 

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -769,11 +769,13 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
       val allResultsById = allResults.groupBy(_.id)
       val multiple = allResultsById.filter(_._2.size > 1)
       if (multiple.nonEmpty) {
-        throw new Exception(s"id(s) with more than one result: ${multiple}")
+        throw new Exception(
+            s"One or more file IDs did not have a project specified and returned multiple search results: ${multiple}"
+        )
       }
       val missing = filesById.keySet.diff(allResultsById.keySet)
       if (missing.nonEmpty) {
-        throw new Exception(s"id(s) not found: ${missing.mkString(",")}")
+        throw new Exception(s"One or more file id(s) were not found: ${missing.mkString(",")}")
       }
     }
 

--- a/api/src/main/scala/dx/api/DxInstanceType.scala
+++ b/api/src/main/scala/dx/api/DxInstanceType.scala
@@ -483,7 +483,8 @@ object InstanceTypeDB extends DefaultJsonProtocol {
   // TODO: move this to DxOrg and DxUser objects
   private def getPricingModel(dxApi: DxApi,
                               billTo: String,
-                              region: String): Option[Map[String, Float]] = {
+                              region: String,
+                              logger: Logger): Option[Map[String, Float]] = {
     val request = Map("fields" -> JsObject("pricingModelsByRegion" -> JsTrue))
     Try {
       billTo match {
@@ -514,7 +515,9 @@ object InstanceTypeDB extends DefaultJsonProtocol {
             }
           }
       case Failure(_: dx.PermissionDeniedException) => None
-      case Failure(ex)                              => throw ex
+      case Failure(ex) =>
+        logger.error(s"Error retrieving the pricing model for billTo ${billTo}", Some(ex))
+        None
     }
   }
 
@@ -538,7 +541,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
         )
     )
     val availableInstanceTypes =
-      getPricingModel(api, projectDesc.billTo.get, projectDesc.region.get)
+      getPricingModel(api, projectDesc.billTo.get, projectDesc.region.get, logger)
         .map { pricingModel =>
           allInstanceTypes.keySet
             .intersect(pricingModel.keySet)


### PR DESCRIPTION
When requesting the pricing model, catch just the PermissionDeniedError, and return None on error or if the pricing model is empty.