### PR TITLE
Use current project as workspace when not in job context

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 * Adds option to `DxApi.describeFilesBulk` to search first in the workspace container
 * `DxApi.resolveDataObject` now searches in the current workspace and/or project if the project is not specified explicitly
 * Refactors `DxFindDataObjects` to use separate `DxFindDataObjectsConstraints` class for specifying constraints
+* Uses the currently select project ID as the workspace ID when not running in a job.
 
 ## 0.5.2 (2021-06-29)
 

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -7,7 +7,7 @@ import com.dnanexus.{DXAPI, DXEnvironment}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import dx.api.DxPath.DxPathComponents
 import dx.AppInternalException
-import dx.util.{FileUtils, Logger, SysUtils, TraceLevel}
+import dx.util.{FileUtils, JsUtils, Logger, SysUtils, TraceLevel}
 import dx.util.CollectionUtils.IterableOnceExtensions
 import spray.json._
 
@@ -593,43 +593,36 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
   }
 
   private def submitResolutionRequest(dxPaths: Vector[DxPathComponents],
-                                      dxProject: DxProject): Map[String, DxDataObject] = {
+                                      dxProject: DxProject,
+                                      mustExist: Boolean = true): Map[String, DxDataObject] = {
     val objectReqs: Vector[JsValue] = dxPaths.map(createResolutionRequest)
     val request = Map("objects" -> JsArray(objectReqs), "project" -> JsString(dxProject.id))
     val responseJs = resolveDataObjects(request)
-    val resultsPerObj: Vector[JsValue] = responseJs.fields.get("results") match {
-      case Some(JsArray(x)) => x
-      case other            => throw new Exception(s"API call returned invalid data ${other}")
-    }
-    resultsPerObj.zipWithIndex.map {
-      case (descJs: JsValue, i) =>
-        val path = dxPaths(i).sourcePath
-        val o = descJs match {
-          case JsArray(x) if x.isEmpty =>
-            throw new Exception(
-                s"Path ${path} not found req=${objectReqs(i)}, i=${i}, project=${dxProject.id}"
-            )
-          case JsArray(x) if x.length == 1 => x(0)
-          case JsArray(_) =>
-            throw new Exception(s"Found more than one dx object in path ${path}")
-          case obj: JsObject => obj
-          case other         => throw new Exception(s"malformed json ${other}")
-        }
-        val fields = o.asJsObject.fields
-        val dxid = fields.get("id") match {
-          case Some(JsString(x)) => x
-          case _                 => throw new Exception("no id returned")
-        }
-
-        // could be a container, not a project
-        val dxContainer: Option[DxProject] = fields.get("project") match {
-          case Some(JsString(x)) => Some(project(x))
-          case _                 => None
-        }
-
-        // safe conversion to a dx-object
-        path -> dataObject(dxid, dxContainer)
-    }.toMap
+    JsUtils
+      .getValues(responseJs.fields, "results")
+      .zipWithIndex
+      .flatMap {
+        case (descJs, i) =>
+          val path = dxPaths(i).sourcePath
+          val result = descJs match {
+            case JsArray(Vector()) if mustExist =>
+              throw new Exception(
+                  s"Path ${path} not found req=${objectReqs(i)}, i=${i}, project=${dxProject.id}"
+              )
+            case JsArray(Vector())              => None
+            case JsArray(Vector(obj: JsObject)) => Some(obj)
+            case JsArray(_) =>
+              throw new Exception(s"Found more than one dx object in path ${path}")
+            case obj: JsObject => Some(obj)
+            case other         => throw new Exception(s"malformed json ${other}")
+          }
+          result.map { obj =>
+            val dxId = JsUtils.getString(obj.fields, "id")
+            val dxContainer = JsUtils.getOptionalString(obj.fields, "project").map(project)
+            path -> dataObject(dxId, dxContainer)
+          }
+      }
+      .toMap
   }
 
   def resolveDataObject(dxPath: String,
@@ -645,7 +638,7 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
           Vector(
               currentWorkspace,
               currentProject
-          ).flatten
+          ).flatten.distinct
       )
 
     // peel off objects that have already been resolved
@@ -657,15 +650,14 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
         )
       case Right(dxPathsToResolve) =>
         searchContainers.iterator
-          .map { proj =>
-            (submitResolutionRequest(Vector(dxPathsToResolve), proj).values.toVector, proj)
-          }
-          .collectFirst {
-            case (Vector(result), _) => result
-            case (result, proj) if result.size > 1 =>
+          .collectFirstDefined { proj =>
+            val result = submitResolutionRequest(Vector(dxPathsToResolve), proj, mustExist = false)
+            if (result.size > 1) {
               throw new Exception(
-                  s"Found more than one dx:object for path ${dxPath} in project=${proj}"
+                  s"Found more than one object for path ${dxPath} in project ${proj}"
               )
+            }
+            result.headOption.map(_._2)
           }
           .getOrElse(
               throw new Exception(s"Could not find ${dxPath} in any of ${searchContainers}")

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -55,7 +55,7 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
   // The current workspace if we are running in an execution environment,
   // otherwise the current project.
   val currentWorkspaceId: Option[String] =
-    Option(dxEnv.getWorkspace).orElse(Option.when(currentJobId.isEmpty)(currentProjectId))
+    Option(dxEnv.getWorkspace).orElse(Option.when(currentJobId.isEmpty)(currentProjectId).flatten)
   lazy val currentWorkspace: Option[DxProject] = currentWorkspaceId.map(DxProject(_)(this))
   // Convert from spray-json to jackson JsonNode
   // Used to convert into the JSON datatype used by dxjava

--- a/api/src/main/scala/dx/api/DxFindDataObjects.scala
+++ b/api/src/main/scala/dx/api/DxFindDataObjects.scala
@@ -307,7 +307,7 @@ case class DxFindDataObjects(dxApi: DxApi = DxApi.get,
     val request = requiredFields ++ limitField ++ constraints.toJson
     if (constraints.project.isEmpty) {
       logger.warning(
-          """Calling findDataObjects without a project can cause result in longer response times 
+          """Calling findDataObjects without a project can cause result in longer response times
             |and greater load on the API server""".stripMargin.replaceAll("\n", " ")
       )
       if (logger.isVerbose) {

--- a/api/src/test/scala/dx/api/DxFileTest.scala
+++ b/api/src/test/scala/dx/api/DxFileTest.scala
@@ -150,8 +150,9 @@ class DxFileTest extends AnyFlatSpec with Matchers {
   }
 
   it should "bulk describe file which is in two projects, project where to search is not given" taggedAs ApiTest in {
+    // describeFilesBulk looks first in the currently selected project if a project is not specified
     val results = dxApi.describeFilesBulk(Vector(FILE_IN_TWO_PROJS_WO_PROJ))
     results.forall(_.hasCachedDesc) shouldBe true
-    results.size shouldBe 2
+    results.size shouldBe 1
   }
 }

--- a/api/src/test/scala/dx/api/DxFindDataObjectsTest.scala
+++ b/api/src/test/scala/dx/api/DxFindDataObjectsTest.scala
@@ -33,7 +33,7 @@ class DxFindDataObjectsTest extends AnyFlatSpec with Matchers {
                                    folder = Some("/test_data"),
                                    nameGlob = Some("*.txt"))
     val results = findDataObjects.query(constraints)
-    results.size shouldBe 6
+    results.size shouldBe 7
   }
 
   it should "find all text files recursively" taggedAs ApiTest in {
@@ -43,7 +43,7 @@ class DxFindDataObjectsTest extends AnyFlatSpec with Matchers {
                                    recurse = true,
                                    nameGlob = Some("*.txt"))
     val results = findDataObjects.query(constraints)
-    results.size shouldBe 15
+    results.size shouldBe 16
   }
 
   it should "find files with specific names" taggedAs ApiTest in {


### PR DESCRIPTION
This implements the behavior of dx-toolkit, which is to use the currently selected project ID as the `WORKSPACE_ID` when not running within a job.

* Use current project ID as workspace ID when not in a job context
* In `DxApi.describeFilesBulk`, when `searchWorkspaceFirst=true`, search current project if project is not specified and not in a job context