### PR TITLE
Add method to disambiguate non-addressable `FileSource`s

### DIFF
--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # dxCommon
 
+## in develop
+
+* Adds `getLocalPathForSource` function to `LocalizationDisambiguator` for handling non-addressable `FileSource`s 
+
 ## 0.5.2 (2021-06-29)
 
 * No longer uses `--quiet` option with `docker pull` in `DockerUtils.pullImage`

--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## in develop
 
 * Adds `getLocalPathForSource` function to `LocalizationDisambiguator` for handling non-addressable `FileSource`s 
+* Adds `linkFrom` method to `LocalFileSource`
 
 ## 0.5.2 (2021-06-29)
 

--- a/common/src/main/scala/dx/util/FileSource.scala
+++ b/common/src/main/scala/dx/util/FileSource.scala
@@ -380,6 +380,13 @@ case class LocalFileSource(
     FileUtils.readFileBytes(canonicalPath)
   }
 
+  /**
+    * Creates a symbolic link from `source` to `canonicalPath`.
+    */
+  def linkFrom(source: Path): Unit = {
+    Files.createSymbolicLink(source, canonicalPath)
+  }
+
   // TODO: assess whether it is okay to link instead of copy
   override protected def localizeTo(file: Path): Unit = {
     if (canonicalPath == file) {

--- a/common/src/test/scala/dx/util/LocalizationDisambiguatorTest.scala
+++ b/common/src/test/scala/dx/util/LocalizationDisambiguatorTest.scala
@@ -49,18 +49,18 @@ class LocalizationDisambiguatorTest extends AnyFlatSpec with Matchers {
     val root = Files.createTempDirectory("root")
     root.toFile.deleteOnExit()
     val disambiguator = SafeLocalizationDisambiguator(root, createDirs = false)
-    val v1Path = disambiguator.localize("foo.txt", "container", Some("1.0"))
+    val v1Path = disambiguator.resolve("foo.txt", "container", Some("1.0"))
     // the first file should not have a version specifier
     v1Path.getParent.getFileName.toString should not be "1.0"
-    val v2Path = disambiguator.localize("foo.txt", "container", Some("1.1"))
+    val v2Path = disambiguator.resolve("foo.txt", "container", Some("1.1"))
     // the second file should have a version specifier
     v2Path.getParent.getFileName.toString shouldBe "1.1"
     // a third file with a different name bug same version should be in the same version directory
-    val v3Path = disambiguator.localize("bar.txt", "container", Some("1.1"))
+    val v3Path = disambiguator.resolve("bar.txt", "container", Some("1.1"))
     v2Path.getParent shouldBe v3Path.getParent
     // an exact name and version collision should throw an error
     assertThrows[Exception] {
-      disambiguator.localize("bar.txt", "container", Some("1.1"))
+      disambiguator.resolve("bar.txt", "container", Some("1.1"))
     }
   }
 


### PR DESCRIPTION
Some `FileSource`s aren't addressable - for example "virtual" file nodes created from strings. We need a way to localize these.