### PR TITLE
Do not resolve files during describe

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Unifies parsing of `choices` and `suggestions` in `DxIOParameter`
 * Add tags field to `DxFileDescribe`
+* Better handles errors parsing `describe` calls in `DxFindApps` and `DxFindDataObjects`
 
 ## 0.6.0 (2021-07-12)
 

--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -2,9 +2,9 @@
 
 ## in develop
 
-* Unifies parsing of `choices` and `suggestions` in `DxIOParameter`
+* Unifies parsing of `choices`, `suggestions`, and `default` in `DxIOParameter`
+* No longer attempt to resolve files/projects/folders when parsing a `DxIOParameter`
 * Add tags field to `DxFileDescribe`
-* Better handles errors parsing `describe` calls in `DxFindApps` and `DxFindDataObjects`
 
 ## 0.6.0 (2021-07-12)
 

--- a/api/src/main/scala/dx/api/DxFindApps.scala
+++ b/api/src/main/scala/dx/api/DxFindApps.scala
@@ -47,7 +47,13 @@ case class DxFindApps(dxApi: DxApi, limit: Option[Int] = None) {
     jsv.asJsObject.getFields("id", "describe") match {
       case Seq(JsString(dxid), desc) =>
         val dxApp = dxApi.app(dxid)
-        val dxDesc = parseDescribe(dxApp.id, desc)
+        val dxDesc =
+          try {
+            parseDescribe(dxApp.id, desc)
+          } catch {
+            case t: Throwable =>
+              throw new Exception(s"Error parsing describe for app ${dxid}", t)
+          }
         dxApp.cacheDescribe(dxDesc)
         dxApp
       case _ =>

--- a/api/src/main/scala/dx/api/DxFindApps.scala
+++ b/api/src/main/scala/dx/api/DxFindApps.scala
@@ -16,7 +16,7 @@ case class DxFindApps(dxApi: DxApi, limit: Option[Int] = None) {
       case None         => None
       case Some(JsNull) => None
       case Some(JsArray(iSpecVec)) =>
-        Some(iSpecVec.map(iSpec => IOParameter.parseIoParam(dxApi, iSpec)))
+        Some(iSpecVec.map(iSpec => IOParameter.parse(dxApi, iSpec)))
       case Some(other) =>
         throw new Exception(s"malformed inputSpec field ${other}")
     }
@@ -24,7 +24,7 @@ case class DxFindApps(dxApi: DxApi, limit: Option[Int] = None) {
       case None         => None
       case Some(JsNull) => None
       case Some(JsArray(oSpecVec)) =>
-        Some(oSpecVec.map(oSpec => IOParameter.parseIoParam(dxApi, oSpec)))
+        Some(oSpecVec.map(oSpec => IOParameter.parse(dxApi, oSpec)))
       case Some(other) =>
         throw new Exception(s"malformed output field ${other}")
     }

--- a/api/src/main/scala/dx/api/DxFindDataObjects.scala
+++ b/api/src/main/scala/dx/api/DxFindDataObjects.scala
@@ -249,7 +249,13 @@ case class DxFindDataObjects(dxApi: DxApi = DxApi.get,
       case Seq(JsString(projectId), JsString(objectId), desc) =>
         val dxProject = dxApi.project(projectId)
         val dxDataObject = dxApi.dataObject(objectId, Some(dxProject))
-        val dxDesc = parseDescribe(desc, dxDataObject, dxProject)
+        val dxDesc =
+          try {
+            parseDescribe(desc, dxDataObject, dxProject)
+          } catch {
+            case t: Throwable =>
+              throw new Exception(s"Error parsing describe for ${dxDataObject}", t)
+          }
         dxDataObject match {
           case dataObject: CachingDxObject[_] =>
             dataObject.cacheDescribe(dxDesc)

--- a/api/src/main/scala/dx/api/DxFindDataObjects.scala
+++ b/api/src/main/scala/dx/api/DxFindDataObjects.scala
@@ -156,14 +156,14 @@ case class DxFindDataObjects(dxApi: DxApi = DxApi.get,
     }
     val inputSpec: Option[Vector[IOParameter]] = fields.get("inputSpec") match {
       case Some(JsArray(iSpecVec)) =>
-        Some(iSpecVec.map(iSpec => IOParameter.parseIoParam(dxApi, iSpec)))
+        Some(iSpecVec.map(iSpec => IOParameter.parse(dxApi, iSpec)))
       case None | Some(JsNull) => None
       case Some(other) =>
         throw new Exception(s"malformed inputSpec field ${other}")
     }
     val outputSpec: Option[Vector[IOParameter]] = fields.get("outputSpec") match {
       case Some(JsArray(oSpecVec)) =>
-        Some(oSpecVec.map(oSpec => IOParameter.parseIoParam(dxApi, oSpec)))
+        Some(oSpecVec.map(oSpec => IOParameter.parse(dxApi, oSpec)))
       case None | Some(JsNull) => None
       case Some(other) =>
         throw new Exception(s"malformed output field ${other}")

--- a/api/src/main/scala/dx/api/DxIoParameter.scala
+++ b/api/src/main/scala/dx/api/DxIoParameter.scala
@@ -66,31 +66,38 @@ final case class IOParameterValueString(value: String) extends IOParameterValue
 final case class IOParameterValueNumber(value: BigDecimal) extends IOParameterValue
 final case class IOParameterValueBoolean(value: Boolean) extends IOParameterValue
 final case class IOParameterValueArray(array: Vector[IOParameterValue]) extends IOParameterValue
-final case class IOParameterValueFile(value: Option[DxFile],
-                                      name: Option[String] = None,
+final case class IOParameterValueFile(id: String,
                                       project: Option[String] = None,
-                                      path: Option[String] = None)
+                                      name: Option[String] = None)
+    extends IOParameterValue {
+  def resolve(dxApi: DxApi = DxApi.get): DxFile = {
+    DxFile(id, project.map(dxApi.project))(dxApi)
+  }
+}
+final case class DxIoParameterValueFolder(project: String, path: String, name: Option[String])
     extends IOParameterValue
 
-object IOParameterValueFile {
-  def forField(field: String,
-               value: Option[DxFile],
-               name: Option[String] = None,
-               project: Option[String] = None,
-               path: Option[String] = None): IOParameterValueFile = {
+object IOParameterValue {
+  def forFileField(field: String,
+                   id: Option[String],
+                   project: Option[String] = None,
+                   name: Option[String] = None,
+                   path: Option[String] = None): IOParameterValue = {
     field match {
-      case DxIOSpec.Default if Seq(name, project, path).forall(_.isEmpty) =>
-        IOParameterValueFile(value)
+      case DxIOSpec.Default if id.isDefined && Seq(name, project, path).forall(_.isEmpty) =>
+        IOParameterValueFile(id.get)
       case DxIOSpec.Default =>
-        throw new Exception(
-            s"file value may not have name, project, or path for field ${DxIOSpec.Default}"
-        )
-      case DxIOSpec.Choices if path.isEmpty =>
-        IOParameterValueFile(value, name, project)
+        throw new Exception("default file value may not have name, project, or path")
+      case DxIOSpec.Choices if id.isDefined && path.isEmpty =>
+        IOParameterValueFile(id.get, project, name)
       case DxIOSpec.Choices =>
-        throw new Exception(s"file value may not have path for field ${DxIOSpec.Choices}")
+        throw new Exception("choice file value requires a file ID and may not have path")
+      case DxIOSpec.Suggestions if id.isDefined && path.isEmpty =>
+        IOParameterValueFile(id.get, project, name)
+      case DxIOSpec.Suggestions if id.isEmpty && project.isDefined && path.isDefined =>
+        DxIoParameterValueFolder(project.get, path.get, name)
       case DxIOSpec.Suggestions =>
-        IOParameterValueFile(value, name, project, path)
+        throw new Exception("suggestion file value requires either file ID or project and path")
       case _ =>
         throw new Exception(s"unrecognized field ${field}")
     }
@@ -113,137 +120,35 @@ case class IOParameter(
 )
 
 object IOParameter {
-  def parseIoParam(dxApi: DxApi, jsv: JsValue, logger: Logger = Logger.get): IOParameter = {
-    val ioParam = jsv.asJsObject.getFields(DxIOSpec.Name, DxIOSpec.Class) match {
-      case Seq(JsString(name), JsString(klass)) =>
-        val ioClass = DxIOClass.fromString(klass)
-        IOParameter(name, ioClass, optional = false)
-      case other =>
-        throw new Exception(s"Malformed io spec ${other}")
-    }
-    val optFlag = jsv.asJsObject.fields.get(DxIOSpec.Optional) match {
-      case Some(JsBoolean(b)) => b
-      case None               => false
-    }
-    val group = jsv.asJsObject.fields.get(DxIOSpec.Group) match {
-      case Some(JsString(s)) => Some(s)
-      case _                 => None
-    }
-    val help = jsv.asJsObject.fields.get(DxIOSpec.Help) match {
-      case Some(JsString(s)) => Some(s)
-      case _                 => None
-    }
-    val label = jsv.asJsObject.fields.get(DxIOSpec.Label) match {
-      case Some(JsString(s)) => Some(s)
-      case _                 => None
-    }
-    val patterns = jsv.asJsObject.fields.get(DxIOSpec.Patterns) match {
-      case Some(JsArray(a)) =>
-        Some(IOParameterPatternArray(a.flatMap {
-          case JsString(s) => Some(s)
-          case _           => None
-        }))
-      case Some(JsObject(obj)) =>
-        val name = obj.get("name") match {
-          case Some(JsArray(array)) =>
-            Some(array.flatMap {
-              case JsString(s) => Some(s)
-              case _           => None
-            })
-          case _ => None
-        }
-        val tag = obj.get("tag") match {
-          case Some(JsArray(array)) =>
-            Some(array.flatMap {
-              case JsString(s) => Some(s)
-              case _           => None
-            })
-          case _ =>
-            None
-        }
-        val klass = obj.get("class") match {
-          case Some(JsString(s)) => Some(s)
-          case _                 => None
-        }
-        Some(IOParameterPatternObject(name, klass, tag))
-      case _ => None
-    }
+  def parse(dxApi: DxApi, jsv: JsValue): IOParameter = {
+    val fields = jsv.asJsObject.fields
+    val ioClass = DxIOClass.fromString(JsUtils.getString(fields, DxIOSpec.Class))
 
     def parseValue(key: String, value: JsValue): IOParameterValue = {
-      (ioParam.ioClass, value) match {
+      (ioClass, value) match {
         case (cls, JsArray(array)) if key == DxIOSpec.Default && DxIOClass.isArray(cls) =>
           IOParameterValueArray(array.map(value => parseValue(key, value)))
         case (DxIOClass.File | DxIOClass.FileArray, link @ JsObject(fields))
             if fields.contains(DxUtils.DxLinkKey) =>
-          IOParameterValueFile.forField(key, Some(DxFile.fromJson(dxApi, link)))
+          val dxFile = DxFile.fromJson(dxApi, link)
+          IOParameterValue.forFileField(key, Some(dxFile.id), dxFile.project.map(_.id))
         case (DxIOClass.File | DxIOClass.FileArray, JsObject(fields)) if key != DxIOSpec.Default =>
-          val name = JsUtils.getOptionalString(fields, "name")
-          val project = JsUtils.getOptionalString(fields, "project").flatMap { proj =>
-            try {
-              Some(dxApi.resolveProject(proj))
-            } catch {
-              case t: Throwable =>
-                logger.error(s"Error resolving project ${proj}", exception = Some(t))
-                None
-            }
+          val dxFile = fields.get("value").map {
+            case obj @ JsObject(fields) if fields.contains(DxUtils.DxLinkKey) =>
+              DxFile.fromJson(dxApi, obj)
+            case other =>
+              throw new Exception(s"invalid file ${key} value ${other}")
           }
+          val project =
+            JsUtils.getOptionalString(fields, "project").orElse(dxFile.flatMap(_.project.map(_.id)))
+          val name = JsUtils.getOptionalString(fields, "name")
           val path = Option
             .when(key == DxIOSpec.Suggestions)(JsUtils.getOptionalString(fields, "path"))
             .flatten
-          val dxFile = fields.get("value") match {
-            case Some(JsObject(fields))
-                if fields.contains(DxUtils.DxLinkKey) && project.isDefined =>
-              val link = fields(DxUtils.DxLinkKey) match {
-                case fileId: JsString =>
-                  JsObject("id" -> fileId, "project" -> JsString(project.get.id))
-                case JsObject(fields) if fields.contains("id") =>
-                  JsObject(fields + ("project" -> JsString(project.get.id)))
-                case _ =>
-                  throw new Exception(s"invalid DNAnexus link ${fields}")
-              }
-              Some(DxFile.fromJson(dxApi, JsObject(DxUtils.DxLinkKey -> link)))
-            case Some(obj @ JsObject(fields)) if fields.contains(DxUtils.DxLinkKey) =>
-              Some(DxFile.fromJson(dxApi, obj))
-            case None if key == DxIOSpec.Suggestions && project.isDefined && path.isDefined =>
-              try {
-                Some(dxApi.resolveDataObject(path.get, project) match {
-                  case file: DxFile => file
-                  case other        => throw new Exception(s"expected object of type file, not ${other}")
-                })
-              } catch {
-                case t: Throwable =>
-                  logger.error(s"Error resolving ${project.get.id}:${path.get}",
-                               exception = Some(t))
-                  None
-              }
-            case None if project.isDefined && name.isDefined =>
-              try {
-                Some(dxApi.resolveDataObject(s"/${name.get}", project) match {
-                  case file: DxFile => file
-                  case other        => throw new Exception(s"expected object of type file, not ${other}")
-                })
-              } catch {
-                case t: Throwable =>
-                  logger.error(s"Error resolving ${project.get.id}:/${name.get}",
-                               exception = Some(t))
-                  None
-              }
-            case other =>
-              throw new Exception(
-                  s"choice value for parameter of type ${ioParam.ioClass} must be a DNAnexus link, not ${other}"
-              )
-          }
-          IOParameterValueFile.forField(key, dxFile, name, project.map(_.id), path)
+          IOParameterValue.forFileField(key, dxFile.map(_.id), project, name, path)
         case (DxIOClass.File | DxIOClass.FileArray, JsString(s)) if key != DxIOSpec.Default =>
-          val dxFile =
-            try {
-              Some(dxApi.resolveFile(s))
-            } catch {
-              case t: Throwable =>
-                logger.error(s"Error resolving file ${s}", exception = Some(t))
-                None
-            }
-          IOParameterValueFile.forField(key, dxFile)
+          val parsed = DxPath.parse(s)
+          IOParameterValue.forFileField(key, Some(parsed.name), parsed.projName)
         case (DxIOClass.String | DxIOClass.StringArray, JsString(s)) =>
           IOParameterValueString(s)
         case (DxIOClass.Int | DxIOClass.IntArray, JsNumber(n)) if n.isValidLong =>
@@ -253,10 +158,51 @@ object IOParameter {
         case (DxIOClass.Boolean | DxIOClass.BooleanArray, JsBoolean(b)) =>
           IOParameterValueBoolean(b)
         case _ =>
-          throw new Exception(s"Unexpected choice ${jsv} of type ${ioParam.ioClass}")
+          throw new Exception(s"Unexpected ${key} value ${jsv} of type ${ioClass}")
       }
     }
 
+    def parseType(value: JsValue): DxConstraint = {
+      value match {
+        case JsString(s) => DxConstraintString(s)
+        case JsObject(fields) =>
+          if (fields.size != 1) {
+            throw new Exception("Constraint hash must have exactly one '$and' or '$or' key")
+          }
+          fields.head match {
+            case (DxConstraintOper.And.name, JsArray(array)) =>
+              DxConstraintBool(DxConstraintOper.And, DxConstraintArray(array.map(parseType)))
+            case (DxConstraintOper.Or.name, JsArray(array)) =>
+              DxConstraintBool(DxConstraintOper.Or, DxConstraintArray(array.map(parseType)))
+            case _ =>
+              throw new Exception(
+                  "Constraint must have key '$and' or '$or' and an array value"
+              )
+          }
+        case _ => throw new Exception(s"Invalid paramter type value ${value}")
+      }
+    }
+
+    val name = JsUtils.getString(fields, DxIOSpec.Name)
+    val optional = JsUtils.getOptionalBoolean(fields, DxIOSpec.Optional).getOrElse(false)
+    val group = JsUtils.getOptionalString(fields, DxIOSpec.Group)
+    val help = JsUtils.getOptionalString(fields, DxIOSpec.Help)
+    val label = JsUtils.getOptionalString(fields, DxIOSpec.Label)
+    val patterns = JsUtils.getOptional(fields, DxIOSpec.Patterns).map {
+      case JsArray(array) => IOParameterPatternArray(array.map(JsUtils.getString(_)))
+      case JsObject(obj) =>
+        val name = obj.get("name").map {
+          case JsArray(array) => array.map(JsUtils.getString(_))
+          case other          => throw new Exception(s"invalid pattern name ${other}")
+        }
+        val tag = obj.get("tag").map {
+          case JsArray(array) => array.map(JsUtils.getString(_))
+          case other          => throw new Exception(s"invalid pattern tag ${other}")
+        }
+        val cls = obj.get("class").map(JsUtils.getString(_))
+        IOParameterPatternObject(name, cls, tag)
+      case other => throw new Exception(s"invalid patterns ${other}")
+    }
     val choices = JsUtils.getOptionalValues(jsv, DxIOSpec.Choices).map { array =>
       array.map(item => parseValue(DxIOSpec.Choices, item))
     }
@@ -267,16 +213,16 @@ object IOParameter {
       try {
         Some(parseValue(DxIOSpec.Default, value))
       } catch {
-        // Currently, some valid defaults won't parse, so we ignore them for now
-        case _: Exception => None
+        case _: Exception =>
+          Logger.get.warning(s"unable to parse field ${name} default value ${value}")
+          None
       }
     }
-    val dxType = jsv.asJsObject.fields.get(DxIOSpec.Type) match {
-      case Some(v: JsValue) => Some(ioParamTypeFromJs(v))
-      case _                => None
-    }
-    ioParam.copy(
-        optional = optFlag,
+    val dxType = JsUtils.getOptional(fields, DxIOSpec.Type).map(parseType)
+    IOParameter(
+        name = name,
+        ioClass = ioClass,
+        optional = optional,
         group = group,
         help = help,
         label = label,
@@ -288,28 +234,7 @@ object IOParameter {
     )
   }
 
-  def ioParamTypeFromJs(value: JsValue): DxConstraint = {
-    value match {
-      case JsString(s) => DxConstraintString(s)
-      case JsObject(fields) =>
-        if (fields.size != 1) {
-          throw new Exception("Constraint hash must have exactly one '$and' or '$or' key")
-        }
-        fields.head match {
-          case (DxConstraintOper.And.name, JsArray(array)) =>
-            DxConstraintBool(DxConstraintOper.And, DxConstraintArray(array.map(ioParamTypeFromJs)))
-          case (DxConstraintOper.Or.name, JsArray(array)) =>
-            DxConstraintBool(DxConstraintOper.Or, DxConstraintArray(array.map(ioParamTypeFromJs)))
-          case _ =>
-            throw new Exception(
-                "Constraint must have key '$and' or '$or' and an array value"
-            )
-        }
-      case _ => throw new Exception(s"Invalid paramter type value ${value}")
-    }
-  }
-
   def parseIOSpec(dxApi: DxApi, specs: Vector[JsValue]): Vector[IOParameter] = {
-    specs.map(ioSpec => parseIoParam(dxApi, ioSpec))
+    specs.map(ioSpec => parse(dxApi, ioSpec))
   }
 }

--- a/api/src/main/scala/dx/api/DxIoParameter.scala
+++ b/api/src/main/scala/dx/api/DxIoParameter.scala
@@ -171,12 +171,26 @@ object IOParameter {
                 case Some(obj @ JsObject(fields)) if fields.contains(DxUtils.DxLinkKey) =>
                   DxFile.fromJson(dxApi, obj)
                 case None if project.isDefined && path.isDefined =>
-                  dxApi.resolveDataObject(path.get, project) match {
+                  val resolved =
+                    try {
+                      dxApi.resolveDataObject(path.get, project)
+                    } catch {
+                      case t: Throwable =>
+                        throw new Exception(s"Error resolving ${project.get.id}:${path.get}", t)
+                    }
+                  resolved match {
                     case file: DxFile => file
                     case other        => throw new Exception(s"expected object of type file, not ${other}")
                   }
                 case None if project.isDefined && name.isDefined =>
-                  dxApi.resolveDataObject(s"/${name.get}", project) match {
+                  val resolved =
+                    try {
+                      dxApi.resolveDataObject(s"/${name.get}", project)
+                    } catch {
+                      case t: Throwable =>
+                        throw new Exception(s"Error resolving ${project.get.id}:/${name.get}", t)
+                    }
+                  resolved match {
                     case file: DxFile => file
                     case other        => throw new Exception(s"expected object of type file, not ${other}")
                   }

--- a/api/src/main/scala/dx/api/DxIoParameter.scala
+++ b/api/src/main/scala/dx/api/DxIoParameter.scala
@@ -206,7 +206,7 @@ object IOParameter {
     val choices = JsUtils.getOptionalValues(jsv, DxIOSpec.Choices).map { array =>
       array.map(item => parseValue(DxIOSpec.Choices, item))
     }
-    val suggestions = JsUtils.getOptionalValues(jsv, DxIOSpec.Choices).map { array =>
+    val suggestions = JsUtils.getOptionalValues(jsv, DxIOSpec.Suggestions).map { array =>
       array.map(item => parseValue(DxIOSpec.Suggestions, item))
     }
     val default = JsUtils.getOptional(jsv, DxIOSpec.Default).flatMap { value =>

--- a/api/src/test/scala/dx/api/DxApiTest.scala
+++ b/api/src/test/scala/dx/api/DxApiTest.scala
@@ -9,7 +9,7 @@ import spray.json._
 
 class DxApiTest extends AnyFlatSpec with Matchers {
   assume(isLoggedIn)
-  private val logger = Logger.Quiet
+  private val logger = Logger.Verbose
   private val dxApi: DxApi = DxApi()(logger)
   private val testProject = "dxCompiler_playground"
   private val testRecord = "record-Fgk7V7j0f9JfkYK55P7k3jGY"

--- a/api/src/test/scala/dx/api/DxApiTest.scala
+++ b/api/src/test/scala/dx/api/DxApiTest.scala
@@ -9,7 +9,7 @@ import spray.json._
 
 class DxApiTest extends AnyFlatSpec with Matchers {
   assume(isLoggedIn)
-  private val logger = Logger.Verbose
+  private val logger = Logger.Quiet
   private val dxApi: DxApi = DxApi()(logger)
   private val testProject = "dxCompiler_playground"
   private val testRecord = "record-Fgk7V7j0f9JfkYK55P7k3jGY"


### PR DESCRIPTION
After #40, we are now seeing errors when running `dxni` on some apps, probably due to file paths in suggestions or choices being out of date (i.e. referring to non-existent files). There is not really any reason files/projects/paths need to be resolved when describing an app/applet/workflow, so instead we just store the values.