### PR TITLE
Handle non-file types for choices and suggestions

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -4,7 +4,9 @@
 
 * Unifies parsing of `choices`, `suggestions`, and `default` in `DxIOParameter`
 * No longer attempt to resolve files/projects/folders when parsing a `DxIOParameter`
-* Add tags field to `DxFileDescribe`
+* Adds tags field to `DxFileDescribe`
+* `DxProject` now extends `DxObject` rather than `DxDataObject`
+* Adds `DxApi.dataObjectFromJson` method
 
 ## 0.6.0 (2021-07-12)
 

--- a/api/src/main/scala/dx/api/DxFile.scala
+++ b/api/src/main/scala/dx/api/DxFile.scala
@@ -1,6 +1,5 @@
 package dx.api
 
-import dx.AppInternalException
 import dx.api.DxPath.DxScheme
 import spray.json._
 import dx.util.{Enum, FileUtils}
@@ -256,37 +255,9 @@ object DxFile {
   //   DxUtils.DxLinkKey: "file-F0J6JbQ0ZvgVz1J9q5qKfkqP"
   // }
   def fromJson(dxApi: DxApi, jsValue: JsValue): DxFile = {
-    val innerObj = jsValue match {
-      case JsObject(fields) if fields.contains(DxUtils.DxLinkKey) =>
-        fields(DxUtils.DxLinkKey)
-      case _ =>
-        throw new AppInternalException(
-            s"An object with key '$$dnanexus_link' is expected, not $jsValue"
-        )
-    }
-
-    val (fid, projId): (String, Option[String]) = innerObj match {
-      case JsString(fid) =>
-        // We just have a file-id
-        (fid, None)
-      case JsObject(linkFields) =>
-        // file-id and project-id
-        val fid =
-          linkFields.get("id") match {
-            case Some(JsString(s)) => s
-            case _                 => throw new AppInternalException(s"No file ID found in $jsValue")
-          }
-        linkFields.get("project") match {
-          case Some(JsString(pid: String)) => (fid, Some(pid))
-          case _                           => (fid, None)
-        }
-      case _ =>
-        throw new AppInternalException(s"Could not parse a dxlink from $innerObj")
-    }
-
-    projId match {
-      case None      => DxFile(fid, None)(dxApi)
-      case Some(pid) => DxFile(fid, Some(DxProject(pid)(dxApi)))(dxApi)
+    dxApi.dataObjectFromJson(jsValue) match {
+      case dxFile: DxFile => dxFile
+      case other          => throw new Exception(s"Not a file object ${other}")
     }
   }
 

--- a/api/src/main/scala/dx/api/DxObject.scala
+++ b/api/src/main/scala/dx/api/DxObject.scala
@@ -115,7 +115,9 @@ object DxObject {
   }
 }
 
-trait DxDataObject extends DxObject
+trait DxDataObject extends DxObject {
+  val project: Option[DxProject]
+}
 
 // Objects that can be run on the platform. These are apps, applets, and workflows.
 trait DxExecutable extends DxObject

--- a/api/src/main/scala/dx/api/DxProject.scala
+++ b/api/src/main/scala/dx/api/DxProject.scala
@@ -22,7 +22,7 @@ object ProjectType extends Enum {
 }
 
 // A project is a subtype of a container
-case class DxProject(id: String)(val dxApi: DxApi = DxApi.get) extends DxDataObject {
+case class DxProject(id: String)(val dxApi: DxApi = DxApi.get) extends DxObject {
   val projectType: ProjectType.ProjectType = id match {
     case _ if id.startsWith("project-") =>
       ProjectType.Project


### PR DESCRIPTION
* Adds `DxApi.dataObjectFromJson`
* Allows annotated suggestions/choices for any data object type
* `DxProject` no longer inherits DxDataObject