### PR TITLE
Move parallel file/directory uploading code to dxScala

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## in develop
 
 * Fixes parsing of File-type default values that are a DNAnexus link with a project ID or field reference  
+* Adds `DxApi.uploadFiles` and `DxApi.uploadDirectories`, which support parallel uploading
 
 ## 0.7.0 (2021-07-16)
 

--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## in develop
 
 * Fixes parsing of File-type default values that are a DNAnexus link with a project ID or field reference  
-* Adds `DxApi.uploadFiles` and `DxApi.uploadDirectories`, which support parallel uploading
+* Adds `DxApi.uploadFiles`, `DxApi.uploadStrings`, and `DxApi.uploadDirectories`, which support parallel uploading
 
 ## 0.7.0 (2021-07-16)
 

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -11,6 +11,42 @@ import dx.util.{FileUtils, JsUtils, Logger, SysUtils, TraceLevel}
 import dx.util.CollectionUtils.IterableOnceExtensions
 import spray.json._
 
+import java.util.concurrent.{Callable, Executors, RejectedExecutionException}
+import scala.annotation.tailrec
+
+/**
+  * A file to upload.
+  * @param source The source file.
+  * @param destination Optional destination project and/or path; defaults to the
+  *                    context project and root folder.
+  * @param tags tags to add to the uploaded file.
+  * @param properties properties to add to the uploaded file.
+  */
+case class FileUpload(source: Path,
+                      destination: Option[String] = None,
+                      tags: Set[String] = Set.empty,
+                      properties: Map[String, String] = Map.empty)
+
+/**
+  * A directory to upload.
+  * @param source The source directory
+  * @param destination Optional destination project and/or folder; defaults to the
+  *                    context project and root folder.
+  * @param recursive Whether to search recursively in `source` for files/directories
+  *                  to upload.
+  * @param listing Set of files/folders to include in the upload; if a folder is
+  *                included, all of its files and subfolders are included regardless
+  *                of whether they appear in the Set individually.
+  * @param tags tags to add to all the uploaded files.
+  * @param properties properties to add to all the uploaded files.
+  */
+case class DirectoryUpload(source: Path,
+                           destination: Option[String] = None,
+                           recursive: Boolean = true,
+                           listing: Option[Set[Path]] = None,
+                           tags: Set[String] = Set.empty,
+                           properties: Map[String, String] = Map.empty)
+
 object DxApi {
   val ResultsPerCallLimit: Int = 1000
   val MaxNumDownloadBytes: Long = 2 * 1024 * 1024 * 1024
@@ -1060,46 +1096,134 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
     uploadFile(path, Some(destination), wait = wait, tags = tags, properties = properties)
   }
 
-  private case class UploadFileVisitor(sourceDir: Path,
-                                       destination: Option[String],
-                                       waitOnUpload: Boolean,
-                                       filter: Option[Path => Boolean])
-      extends SimpleFileVisitor[Path] {
-    private def ensureEndsWithSlash(path: String): String = {
+  def uploadFiles(
+      files: Iterable[FileUpload],
+      waitOnUpload: Boolean = false,
+      parallel: Boolean = true,
+      maxConcurrent: Int = SysUtils.availableCores
+  ): Map[Path, DxFile] = {
+    if (files.isEmpty) {
+      return Map.empty
+    }
+
+    if (parallel && files.size > 1) {
+      val executor = Executors.newFixedThreadPool(Math.min(files.size, maxConcurrent))
+
+      def shutdown(now: Boolean = false): Unit = {
+        try {
+          if (now) {
+            executor.shutdownNow()
+          } else {
+            executor.shutdown()
+          }
+        } catch {
+          case se: SecurityException =>
+            logger.warning(
+                "Unexpected security exception shutting down upload thread pool executor",
+                exception = Some(se)
+            )
+        }
+      }
+
+      case class UploadCallable(upload: FileUpload) extends Callable[(Path, DxFile)] {
+        override def call(): (Path, DxFile) = {
+          upload.source -> uploadFile(path = upload.source,
+                                      destination = upload.destination,
+                                      wait = waitOnUpload,
+                                      tags = upload.tags,
+                                      properties = upload.properties)
+        }
+      }
+
+      // submit all upload jobs
+      val callables = files.map(UploadCallable).toVector
+      val futures =
+        try {
+          callables.map { callable: Callable[(Path, DxFile)] =>
+            executor.submit(callable)
+          }
+        } catch {
+          case re: RejectedExecutionException =>
+            shutdown(now = true)
+            throw new Exception("Unexpected rejection of file upload task", re)
+        }
+
+      // try to shut down the threadpool gracefully - this will let the submitted jobs finish
+      shutdown()
+
+      // wait for all jobs to complete - throw exception if any of the uploads fail
+      futures.zipWithIndex.toMap.map {
+        case (f, index) =>
+          try {
+            f.get
+          } catch {
+            case t: Throwable =>
+              shutdown(now = true)
+              throw new Exception(s"Error uploading ${callables(index).upload.source}", t)
+          }
+      }
+    } else {
+      files.map {
+        case FileUpload(path, dest, tags, properties) =>
+          path -> uploadFile(path = path,
+                             destination = dest,
+                             wait = waitOnUpload,
+                             tags = tags,
+                             properties = properties)
+      }.toMap
+    }
+  }
+
+  private def parseDestination(destination: Option[String]): (String, String) = {
+    def ensureEndsWithSlash(path: String): String = {
       if (path.endsWith("/")) path else s"${path}/"
     }
 
-    val (projectId: Option[String], folder: String) = destination
+    destination
       .map { dest =>
         dest.split(":").toVector match {
           case Vector(projectId) if projectId.startsWith("project-") =>
-            (Some(projectId), "/")
+            (projectId, "/")
           case Vector(folder) =>
-            (None, ensureEndsWithSlash(folder))
+            (currentWorkspaceId.get, ensureEndsWithSlash(folder))
           case Vector(projectId, folder) =>
-            (Some(projectId), ensureEndsWithSlash(folder))
+            (projectId, ensureEndsWithSlash(folder))
           case _ =>
             throw new Exception(s"invalid destination ${dest}")
         }
       }
-      .getOrElse((None, "/"))
+      .getOrElse((currentWorkspaceId.get, "/"))
+  }
 
-    private var uploadedFiles = Map.empty[Path, DxFile]
+  private def getFileUploadsForDirectory(
+      sourceDir: Path,
+      destProject: String,
+      destFolder: String,
+      recursive: Boolean,
+      filter: Option[Path => Boolean],
+      tags: Set[String],
+      properties: Map[String, String]
+  ): Vector[FileUpload] = {
+    class UploadFileVisitor extends SimpleFileVisitor[Path] {
+      var files = Vector.empty[FileUpload]
 
-    def result: (Option[String], String, Map[Path, DxFile]) = {
-      (projectId, folder, uploadedFiles)
-    }
-
-    override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-      if (!attrs.isDirectory && filter.forall(f => f(file))) {
-        val fileRelPath = sourceDir.relativize(file)
-        val fileDestPath = s"${folder}${fileRelPath}"
-        val fileDest = projectId.map(p => s"${p}:${fileDestPath}").getOrElse(fileDestPath)
-        val dxFile = uploadFile(file, Some(fileDest), waitOnUpload)
-        uploadedFiles += (file -> dxFile)
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        if (!attrs.isDirectory && filter.forall(f => f(file))) {
+          val fileRelPath = sourceDir.relativize(file)
+          val fileDest = s"${destProject}:${destFolder}${fileRelPath}"
+          files :+= FileUpload(file, Some(fileDest), tags, properties)
+        }
+        FileVisitResult.CONTINUE
       }
-      FileVisitResult.CONTINUE
     }
+
+    val visitor = new UploadFileVisitor
+    val maxDepth = if (recursive) Integer.MAX_VALUE else 1
+    Files.walkFileTree(sourceDir,
+                       javautil.EnumSet.noneOf(classOf[FileVisitOption]),
+                       maxDepth,
+                       visitor)
+    visitor.files
   }
 
   /**
@@ -1112,17 +1236,82 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DXEnvironment
     * @param recursive whether to upload all subdirectories
     * @param wait whether to wait for each upload to complete
     * @param filter optional filter function to determine which files to upload
+    * @param tags tags to add to all the uploaded files.
+    * @param properties properties to add to all the uploaded files.
+    * @param parallel whether to upload files in parallel
+    * @param maxConcurrent maximum number of concurrent uploads
     */
   def uploadDirectory(
       path: Path,
       destination: Option[String] = None,
       recursive: Boolean = true,
       wait: Boolean = false,
-      filter: Option[Path => Boolean] = None
-  ): (Option[String], String, Map[Path, DxFile]) = {
-    val visitor = UploadFileVisitor(path, destination, wait, filter)
-    val maxDepth = if (recursive) Integer.MAX_VALUE else 1
-    Files.walkFileTree(path, javautil.EnumSet.noneOf(classOf[FileVisitOption]), maxDepth, visitor)
-    visitor.result
+      filter: Option[Path => Boolean] = None,
+      tags: Set[String] = Set.empty,
+      properties: Map[String, String] = Map.empty,
+      parallel: Boolean = true,
+      maxConcurrent: Int = SysUtils.availableCores
+  ): (String, String, Map[Path, DxFile]) = {
+    val (projectId, folder) = parseDestination(destination)
+    val uploads =
+      getFileUploadsForDirectory(path, projectId, folder, recursive, filter, tags, properties)
+    (projectId, folder, uploadFiles(uploads, wait, parallel, maxConcurrent))
+  }
+
+  /**
+    * Uploads directories to the context project and folder.
+    *
+    * @param dirs directories to upload
+    * @param wait whether to wait for each upload to complete
+    * @param parallel whether to upload files in parallel
+    * @param maxConcurrent maximum number of concurrent uploads
+    * @return mapping of source path to (projectId, folder, uploaded files)
+    */
+  def uploadDirectories(
+      dirs: Set[DirectoryUpload],
+      wait: Boolean = false,
+      parallel: Boolean = true,
+      maxConcurrent: Int = SysUtils.availableCores
+  ): Map[Path, (String, String, Map[Path, DxFile])] = {
+    def includePath(path: Path, paths: Set[Path]): Boolean = {
+      @tailrec
+      def containsAncestor(child: Path): Boolean = {
+        Option(child.getParent) match {
+          case Some(parent) => paths.contains(parent) || containsAncestor(parent)
+          case None         => false
+        }
+      }
+      paths.contains(path) || (path.toFile.isFile && containsAncestor(path))
+    }
+
+    val (fileUploads, sourceFileToSourceDir, sourceDirToDest) = dirs.map {
+      case DirectoryUpload(sourceDir, destination, recursive, listing, tags, properties) =>
+        val filter = listing.map(paths => (path: Path) => includePath(path, paths))
+        val (projectId, folder) = parseDestination(destination)
+        val fileUploads =
+          getFileUploadsForDirectory(sourceDir,
+                                     projectId,
+                                     folder,
+                                     recursive,
+                                     filter,
+                                     tags,
+                                     properties)
+        (fileUploads, fileUploads.map(_.source -> sourceDir), sourceDir -> (projectId, folder))
+    }.unzip3
+    val sourceFileToSourceDirMap = sourceFileToSourceDir.flatten.toMap
+    val sourceDirToDestMap = sourceDirToDest.toMap
+
+    uploadFiles(fileUploads.flatten, wait, parallel, maxConcurrent)
+      .map {
+        case (sourceFile, dxFile) =>
+          val sourceDir = sourceFileToSourceDirMap(sourceFile)
+          (sourceDir, (sourceFile, dxFile))
+      }
+      .groupBy(_._1)
+      .map {
+        case (sourceDir, uploads) =>
+          val (projectId, folder) = sourceDirToDestMap(sourceDir)
+          sourceDir -> (projectId, folder, uploads.values.toMap)
+      }
   }
 }

--- a/api/src/test/scala/dx/api/DxApiTest.scala
+++ b/api/src/test/scala/dx/api/DxApiTest.scala
@@ -1,14 +1,19 @@
 package dx.api
 
-import Assumptions.isLoggedIn
+import Assumptions.{isLoggedIn, toolkitCallable}
 import Tags.ApiTest
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import dx.util.Logger
+import dx.util.{FileUtils, Logger}
+import org.scalatest.BeforeAndAfterAll
 import spray.json._
 
-class DxApiTest extends AnyFlatSpec with Matchers {
+import java.nio.file.Files
+import scala.util.Random
+
+class DxApiTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   assume(isLoggedIn)
+  assume(toolkitCallable)
   private val logger = Logger.Quiet
   private val dxApi: DxApi = DxApi()(logger)
   private val testProject = "dxCompiler_playground"
@@ -66,6 +71,64 @@ class DxApiTest extends AnyFlatSpec with Matchers {
     val query = Vector(DxFile("file-XXXXXXXXXXXXXXXXXXXXXXXX", Some(dxTestProject))(dxApi))
     assertThrows[Exception] {
       dxApi.describeFilesBulk(query, validate = true)
+    }
+  }
+
+  private val username = dxApi.whoami()
+  private val uploadPath = s"unit_tests/${username}/test_upload"
+  private val testDir = Files.createTempDirectory("test")
+  private val random = new Random(42)
+  private val files = Iterator
+    .range(0, 5)
+    .map { i =>
+      val path = testDir.resolve(s"file_${i}.txt")
+      val length = random.nextInt(1024 * 10)
+      val content = random.nextString(length)
+      FileUtils.writeFileContent(path, content)
+      val fileSize = content.getBytes().length
+      fileSize shouldBe Files.size(path)
+      (path, fileSize)
+    }
+    .toMap
+  private val fileTags = Set("A", "B")
+  private val fileProperties = Map("name" -> "Joe", "age" -> "42")
+
+  override protected def afterAll(): Unit = {
+    dxTestProject.removeFolder(s"/${uploadPath}/", recurse = true, force = true)
+  }
+
+  it should "upload files in serial" in {
+    val dest = s"${dxTestProject.id}:/${uploadPath}/serial/"
+    val uploads = files.keys.map { path =>
+      FileUpload(source = path,
+                 destination = Some(dest),
+                 tags = fileTags,
+                 properties = fileProperties)
+    }.toSet
+    val results = dxApi.uploadFiles(uploads, waitOnUpload = true, parallel = false)
+    results.size shouldBe 5
+    results.foreach {
+      case (path, dxFile) =>
+        val desc: DxFileDescribe = dxFile.describe(Set(Field.Tags, Field.Properties))
+        files(path) shouldBe desc.size
+        desc.tags shouldBe Some(fileTags)
+        desc.properties shouldBe Some(fileProperties)
+    }
+  }
+
+  it should "upload files in parallel" in {
+    val dest = s"${dxTestProject.id}:/${uploadPath}/parallel/"
+    val uploads = files.keys.map { path =>
+      FileUpload(path, Some(dest), fileTags, fileProperties)
+    }.toSet
+    val results = dxApi.uploadFiles(uploads, waitOnUpload = true, maxConcurrent = 3)
+    results.size shouldBe 5
+    results.foreach {
+      case (path, dxFile) =>
+        val desc: DxFileDescribe = dxFile.describe(Set(Field.Tags, Field.Properties))
+        files(path) shouldBe desc.size
+        desc.tags shouldBe Some(fileTags)
+        desc.properties shouldBe Some(fileProperties)
     }
   }
 }

--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Removes deprecated constructors from `Logger`
 * Adds converstion to/from JSON to `Logger` (implicit) and `LocalizationDisambiguator` (explicit)
+* Adds `SysUtils.availableCores`
 
 ## 0.6.0 (2021-07-12)
 

--- a/common/src/main/scala/dx/util/FileSource.scala
+++ b/common/src/main/scala/dx/util/FileSource.scala
@@ -14,7 +14,6 @@ import java.nio.file.{
 }
 import java.nio.file.attribute.BasicFileAttributes
 import java.{util => javautil}
-
 import dx.util.FileUtils.{FileScheme, getUriScheme}
 
 import scala.io.Source

--- a/common/src/main/scala/dx/util/FileSource.scala
+++ b/common/src/main/scala/dx/util/FileSource.scala
@@ -14,6 +14,7 @@ import java.nio.file.{
 }
 import java.nio.file.attribute.BasicFileAttributes
 import java.{util => javautil}
+
 import dx.util.FileUtils.{FileScheme, getUriScheme}
 
 import scala.io.Source

--- a/common/src/main/scala/dx/util/SysUtils.scala
+++ b/common/src/main/scala/dx/util/SysUtils.scala
@@ -93,6 +93,11 @@ object SysUtils {
   }
 
   /**
+    * Number of avaialable CPU cores.
+    */
+  lazy val availableCores: Int = Runtime.getRuntime.availableProcessors()
+
+  /**
     * Times the execution of a block of code.
     * @param block the block to execute
     * @tparam R the return value type


### PR DESCRIPTION
This PR adds `DxApi.uploadFiles` and `DxApi.uploadDirectories`, which support parallel upload and are direct ports from dxCompiler `FileUploader`.