### PR TITLE
ignore missing docker tarball manifest

### DIFF
--- a/api/src/main/scala/dx/api/DxPath.scala
+++ b/api/src/main/scala/dx/api/DxPath.scala
@@ -31,7 +31,7 @@ object DxPath {
       case Some(proj) if proj.startsWith("file-") =>
         throw new Exception("""|Path ${dxPath} does not look like: dx://PROJECT_NAME:/FILE_PATH
                                |For example:
-                               |   dx://dxWDL_playground:/test_data/fileB
+                               |   dx://dxCompiler_playground:/test_data/fileB
                                |""".stripMargin)
       case _ => ()
     }


### PR DESCRIPTION
If a Docker image tarball does not have a manifest, we should ignore it and try to get the image name from the output of `docker load` instead.