### PR TITLE
APPS-955 Update to JDK 11, Scala 2.13.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,15 @@ jobs:
           pip3 install setuptools wheel
           pip3 install termcolor
           pip3 install dxpy
+      - name: Check formatting
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sbt scalafmtCheckAll
       - name: Common Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sbt 'project common' scalafmtCheckAll
           sbt 'project common' test
           sbt 'project common' publishLocal
       - name: API Unit Tests
@@ -51,18 +55,15 @@ jobs:
           PROJECT=dxCompiler_playground
           dx select $PROJECT
 
-          sbt 'project api' scalafmtCheckAll
           sbt 'project api' test
           sbt 'project api' publishLocal
       - name: Protocols Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sbt 'project protocols' scalafmtCheckAll
           sbt 'project protocols' test
       - name: Yaml Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sbt 'project yaml' scalafmtCheckAll
           sbt 'project yaml' test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,15 +32,11 @@ jobs:
           pip3 install setuptools wheel
           pip3 install termcolor
           pip3 install dxpy
-      - name: Check formatting
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sbt scalafmtCheckAll
       - name: Common Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          sbt scalafmtCheckAll
           sbt 'project common' test
           sbt 'project common' publishLocal
       - name: API Unit Tests
@@ -55,15 +51,18 @@ jobs:
           PROJECT=dxCompiler_playground
           dx select $PROJECT
 
+          sbt 'project api' scalafmtCheckAll
           sbt 'project api' test
           sbt 'project api' publishLocal
       - name: Protocols Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          sbt 'project protocols' scalafmtCheckAll
           sbt 'project protocols' test
       - name: Yaml Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          sbt 'project yaml' scalafmtCheckAll
           sbt 'project yaml' test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
           pip3 install setuptools wheel
           pip3 install termcolor
           pip3 install dxpy
+          pip3 install --upgrade pyOpenSSL
       - name: Common Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Git Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sbt scalafmtCheckAll
+          sbt 'project common' scalafmtCheckAll
           sbt 'project common' test
           sbt 'project common' publishLocal
       - name: API Unit Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,10 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
-      - name: Check Scala formatting
-        run: |
-          sbt scalafmtCheckAll
       - name: Install Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Install dxpy and other dependencies
         run: |
           sudo apt-get update
@@ -39,6 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          sbt 'project common' scalafmtCheckAll
           sbt 'project common' test
           sbt 'project common' publishLocal
       - name: API Unit Tests
@@ -53,15 +51,18 @@ jobs:
           PROJECT=dxCompiler_playground
           dx select $PROJECT
 
+          sbt 'project api' scalafmtCheckAll
           sbt 'project api' test
           sbt 'project api' publishLocal
       - name: Protocols Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          sbt 'project protocols' scalafmtCheckAll
           sbt 'project protocols' test
       - name: Yaml Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          sbt 'project yaml' scalafmtCheckAll
           sbt 'project yaml' test

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   run-release:
     name: dxApi Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -35,6 +35,7 @@ jobs:
           pip3 install setuptools wheel
           pip3 install termcolor
           pip3 install dxpy
+          pip3 install --upgrade pyOpenSSL
       - name: Build Dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Install dxpy and other dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   run-release:
     name: dxCommon Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-protocols.yml
+++ b/.github/workflows/release-protocols.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   run-release:
     name: dxFileAccessProtocols Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release-protocols.yml
+++ b/.github/workflows/release-protocols.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Install dxpy and other dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/release-yaml.yml
+++ b/.github/workflows/release-yaml.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Install dxpy and other dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/release-yaml.yml
+++ b/.github/workflows/release-yaml.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   run-release:
     name: dxYaml Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Install other dependencies
         run: |
           sudo apt update -y && sudo apt install -y jq

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   publish:
     name: Publish Snapshot
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ gen/
 src/test/resources/corpora
 
 .gradle/
+.java-version

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 project/project
 project/target
 target/
-
+.bsp/
 *.tmp
 
 # Scala metals

--- a/api/src/main/scala/dx/api/DxFile.scala
+++ b/api/src/main/scala/dx/api/DxFile.scala
@@ -285,14 +285,10 @@ object DxFile {
   // those as a vector.
   def findFiles(dxApi: DxApi, jsValue: JsValue): Vector[DxFile] = {
     jsValue match {
-      case JsBoolean(_) | JsNumber(_) | JsString(_) | JsNull =>
-        Vector.empty[DxFile]
-      case JsObject(_) if DxFile.isDxFile(jsValue) =>
-        Vector(DxFile.fromJson(dxApi, jsValue))
-      case JsObject(fields) =>
-        fields.map { case (_, v) => findFiles(dxApi, v) }.toVector.flatten
-      case JsArray(elems) =>
-        elems.flatMap(e => findFiles(dxApi, e))
+      case JsObject(_) if DxFile.isDxFile(jsValue) => Vector(DxFile.fromJson(dxApi, jsValue))
+      case JsObject(fields)                        => fields.map { case (_, v) => findFiles(dxApi, v) }.toVector.flatten
+      case JsArray(elems)                          => elems.flatMap(e => findFiles(dxApi, e))
+      case _                                       => Vector.empty[DxFile]
     }
   }
 }

--- a/api/src/test/scala/dx/api/DxApiTest.scala
+++ b/api/src/test/scala/dx/api/DxApiTest.scala
@@ -14,7 +14,7 @@ import scala.util.Random
 class DxApiTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   assume(isLoggedIn)
   assume(toolkitCallable)
-  private val logger = Logger.Quiet
+  private val logger = Logger.Verbose
   private val dxApi: DxApi = DxApi()(logger)
   private val testProject = "dxCompiler_playground"
   private val testRecord = "record-Fgk7V7j0f9JfkYK55P7k3jGY"

--- a/api/src/test/scala/dx/api/DxApiTest.scala
+++ b/api/src/test/scala/dx/api/DxApiTest.scala
@@ -14,7 +14,7 @@ import scala.util.Random
 class DxApiTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   assume(isLoggedIn)
   assume(toolkitCallable)
-  private val logger = Logger.Verbose
+  private val logger = Logger.Quiet
   private val dxApi: DxApi = DxApi()(logger)
   private val testProject = "dxCompiler_playground"
   private val testRecord = "record-Fgk7V7j0f9JfkYK55P7k3jGY"

--- a/build.sbt
+++ b/build.sbt
@@ -116,8 +116,8 @@ lazy val dependencies =
     val jacksonVersion = "2.13.0"
     val guavaVersion = "23.0"
     val httpClientVersion = "4.5.13"
-    val logbackVersion = "1.2.7"
-    val awsVersion = "2.17.91"
+    val logbackVersion = "1.2.8"
+    val awsVersion = "2.17.99"
     val nettyVersion = "4.1.46.Final"
 
     val dxCommon = "com.dnanexus" % "dxcommon" % dxCommonVersion

--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,7 @@ lazy val globalSettings = Seq(
     // reduce the maximum number of errors shown by the Scala compiler
     maxErrors := 20,
     // scalafmt
-    scalafmtConfig := baseDirectory.value / ".scalafmt.conf",
+    scalafmtConfig := file(".") / ".scalafmt.conf",
     // Publishing
     // disable publish with scala version, otherwise artifact name will include scala version
     // e.g dxScala_2.11

--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ val releaseTarget = Option(System.getProperty("releaseTarget")).getOrElse("githu
 lazy val globalSettings = Seq(
     scalacOptions ++= compilerOptions,
     // javac
-    javacOptions ++= Seq("-Xlint:deprecation"),
+    javacOptions ++= Seq("-Xlint:deprecation", "-source", "1.8", "-target", "1.8"),
     // reduce the maximum number of errors shown by the Scala compiler
     maxErrors := 20,
     // scalafmt

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ name := "dxScala"
 
 // build-wide settings
 ThisBuild / organization := "com.dnanexus"
-ThisBuild / scalaVersion := "2.13.2"
+ThisBuild / scalaVersion := "2.13.7"
 ThisBuild / developers := List(
     Developer("jdidion", "jdidion", "jdidion@dnanexus.com", url("https://github.com/dnanexus-rnd"))
 )
@@ -20,8 +20,8 @@ ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICEN
 
 // PROJECTS
 
-lazy val root = project.in(file("."))
-lazy val global = root
+lazy val root = project
+  .in(file("."))
   .settings(
       globalSettings,
       publish / skip := true
@@ -116,7 +116,7 @@ lazy val dependencies =
     val jacksonVersion = "2.13.0"
     val guavaVersion = "23.0"
     val httpClientVersion = "4.5.13"
-    val logbackVersion = "1.2.8"
+    val logbackVersion = "1.2.9"
     val awsVersion = "2.17.99"
     val nettyVersion = "4.1.46.Final"
 
@@ -156,7 +156,7 @@ lazy val globalSettings = Seq(
     // reduce the maximum number of errors shown by the Scala compiler
     maxErrors := 20,
     // scalafmt
-    scalafmtConfig := root.base / ".scalafmt.conf",
+    scalafmtConfig := baseDirectory.value / ".scalafmt.conf",
     // Publishing
     // disable publish with scala version, otherwise artifact name will include scala version
     // e.g dxScala_2.11
@@ -205,7 +205,6 @@ val compilerOptions = Seq(
     "-Xlint:doc-detached",
     "-Xlint:inaccessible",
     "-Xlint:infer-any",
-    "-Xlint:nullary-override",
     "-Xlint:nullary-unit",
     "-Xlint:option-implicit",
     "-Xlint:package-object-classes",

--- a/common/src/main/scala/dx/util/FileUtils.scala
+++ b/common/src/main/scala/dx/util/FileUtils.scala
@@ -61,8 +61,8 @@ object FileUtils {
       filtered match {
         case Vector()  => new File(".").toPath
         case Vector(p) => new File(p).toPath
-        case Vector(head, tail @ _*) =>
-          tail.foldLeft(new File(head).toPath) {
+        case v =>
+          v.tail.foldLeft(new File(v.head).toPath) {
             case (parent, child) => parent.resolve(child)
           }
       }
@@ -208,7 +208,7 @@ object FileUtils {
   def readFileLines(path: Path, encoding: Charset = DefaultEncoding): Vector[String] = {
     val source = Source.fromFile(path.toString, encoding.name)
     try {
-      source.getLines.toVector
+      source.getLines().toVector
     } finally {
       source.close()
     }

--- a/common/src/main/scala/dx/util/package.scala
+++ b/common/src/main/scala/dx/util/package.scala
@@ -21,8 +21,8 @@ package object util {
     (message, exception) match {
       case (s, Some(e)) if s.nonEmpty && stackTrace => s"${s}\n${exceptionToString(e)}"
       case (s, Some(e)) if s.nonEmpty               => s"${s}: ${exceptionToString(e, brief = true)}"
-      case ("", Some(e)) if stackTrace              => exceptionToString(e)
-      case ("", Some(e))                            => exceptionToString(e, brief = true)
+      case (_, Some(e)) if stackTrace               => exceptionToString(e)
+      case (_, Some(e))                             => exceptionToString(e, brief = true)
       case (s, None)                                => s
     }
   }

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -45,8 +45,8 @@ object Merging {
           MergeStrategy.first
         case _ :+ "module-info.class" =>
           MergeStrategy.discard
-        case other =>
-          val oldStrategy = (assemblyMergeStrategy in assembly).value
+        case _ =>
+          val oldStrategy = (assembly / assemblyMergeStrategy).value
           oldStrategy(x)
       }
     case x @ PathList("OSGI-INF", path @ _*) =>
@@ -56,7 +56,7 @@ object Merging {
         case "l10n" :: "bundle.properties" :: Nil =>
           MergeStrategy.concat
         case _ =>
-          val oldStrategy = (assemblyMergeStrategy in assembly).value
+          val oldStrategy = (assembly / assemblyMergeStrategy).value
           oldStrategy(x)
       }
     case PathList("asm-license.txt") | PathList("module-info.class") | PathList("overview.html") |
@@ -67,7 +67,7 @@ object Merging {
     case PathList("mime.types") =>
       MergeStrategy.last
     case x =>
-      val oldStrategy = (assemblyMergeStrategy in assembly).value
+      val oldStrategy = (assembly / assemblyMergeStrategy).value
       OnErrorMergeStrategy(oldStrategy(x), MergeStrategy.first)
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
 sbt.version=1.5.7
-scalaVersion := "2.13.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 //addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,20 +1,20 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+//addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+//addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 // sbt-sonatype plugin used to publish artifact to maven central via sonatype nexus
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+//addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 // sbt-pgp plugin used to sign the artifcat with pgp keys
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+//addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 // sbt-github-packages plugin used to publish snapshot versions to github packages
 addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.2")
 
 // This prevents the SLF dialog from appearing when starting an SBT session
-libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.24"
+libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.32"
 // only load git plugin if we're actually in a git repo
 libraryDependencies ++= {
-  if (baseDirectory.value / "../.git" isDirectory)
+  if ((baseDirectory.value / "../.git").isDirectory)
     Seq(
         Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-git" % "1.0.0",
                                 (update / sbtBinaryVersion).value,

--- a/yaml/src/main/scala/dx/yaml/YamlValue.scala
+++ b/yaml/src/main/scala/dx/yaml/YamlValue.scala
@@ -128,8 +128,7 @@ case object YamlNegativeInf extends YamlValue {
   * A YAML boolean.
   */
 case class YamlBoolean(boolean: Boolean) extends YamlValue {
-  private[yaml] lazy val snakeYamlObject: Object =
-    new java.lang.Boolean(boolean)
+  private[yaml] lazy val snakeYamlObject: Object = java.lang.Boolean.valueOf(boolean)
 }
 
 /**


### PR DESCRIPTION
The code compiles with both JDK8 and JDK11. Switching to 11 wholesale would be a breaking change, so we probably want to release both 8 and 11 versions (using `-source` and `-target` javac options).