### PR TITLE
runCommand

### DIFF
--- a/common/RELEASE_NOTES.md
+++ b/common/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # dxCommon
 
+## in develop
+
+* Adds `SysUtils.runCommand`, which exposes options for how to handle stdin/stdout/stderr.
+* Adds `Paths.BaseEvalPaths.isLocal` attribute to differentiate local from remote paths.
+* **Breaking** removes `SysUtils.execScript`. Use `runCommand` with the script path as the argument instead.
+
 ## 0.10.1 (2021-12-13)
 
 * Prettify truncated log messages

--- a/common/src/main/scala/dx/util/Paths.scala
+++ b/common/src/main/scala/dx/util/Paths.scala
@@ -26,7 +26,7 @@ trait EvalPaths {
   def getStderrFile(ensureParentExists: Boolean = false): PosixPath
 }
 
-abstract class BaseEvalPaths extends EvalPaths {
+abstract class BaseEvalPaths(isLocal: Boolean = true) extends EvalPaths {
   private var cache: Map[String, PosixPath] = Map.empty
 
   protected def createDir(key: String, path: PosixPath): PosixPath = {
@@ -38,7 +38,9 @@ abstract class BaseEvalPaths extends EvalPaths {
   protected def getOrCreateDir(key: String, path: PosixPath, ensureExists: Boolean): PosixPath = {
     cache.getOrElse(
         key,
-        if (ensureExists) {
+        if (!isLocal) {
+          path
+        } else if (ensureExists) {
           createDir(key, path)
         } else {
           val localPath = path.asJavaPath

--- a/common/src/main/scala/dx/util/SysUtils.scala
+++ b/common/src/main/scala/dx/util/SysUtils.scala
@@ -1,7 +1,6 @@
 package dx.util
 
 import java.lang.management.ManagementFactory
-import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import scala.annotation.nowarn
 import scala.concurrent.{Await, Future, TimeoutException, blocking, duration}
@@ -11,8 +10,8 @@ import scala.sys.process.{Process, ProcessLogger}
 case class CommandExecError(msg: String,
                             command: String,
                             returnCode: Int,
-                            stdout: String,
-                            stderr: String)
+                            stdout: Option[String],
+                            stderr: Option[String])
     extends Exception(
         s"""${msg}
            |Command: ${command}
@@ -23,18 +22,25 @@ case class CommandExecError(msg: String,
 
 case class CommandTimeout(msg: String, command: String, timeout: Int) extends Exception(msg)
 
+object StdMode extends Enum {
+  type StdMode = Value
+  val Capture, Forward, Ignore = Value
+}
+
 object SysUtils {
 
-  def runCommand(command: String,
-                 timeout: Option[Int] = None,
-                 allowedReturnCodes: Set[Int] = Set(0),
-                 exceptionOnFailure: Boolean = true,
-                 connectInput: Boolean = false,
-                 captureStdout: Boolean = true,
-                 captureStderr: Boolean = true): (Int, Option[String], Option[String]) = {
+  def runCommand(
+      command: String,
+      timeout: Option[Int] = None,
+      allowedReturnCodes: Set[Int] = Set(0),
+      exceptionOnFailure: Boolean = true,
+      connectInput: Boolean = false,
+      stdoutMode: StdMode.StdMode = StdMode.Capture,
+      stderrMode: StdMode.StdMode = StdMode.Capture
+  ): (Int, Option[String], Option[String]) = {
     val cmds = Seq("/bin/sh", "-c", command)
-    val outStream = Option.when(captureStdout)(new StringBuilder())
-    val errStream = Option.when(captureStderr)(new StringBuilder())
+    val outStream = Option.when(stdoutMode == StdMode.Capture)(new StringBuilder())
+    val errStream = Option.when(stderrMode == StdMode.Capture)(new StringBuilder())
 
     def getStds: (Option[String], Option[String]) = {
       (outStream.map(_.toString), errStream.map(_.toString))
@@ -42,28 +48,34 @@ object SysUtils {
 
     val fout = outStream
       .map(out => (o: String) => { out.append(o).append("\n"); () })
+      .orElse(Option.when(stdoutMode == StdMode.Forward) { (o: String) =>
+        sys.process.stdout.append(o).append("\n"); ()
+      })
       .getOrElse((_: String) => ())
     val ferr = errStream
       .map(err => (e: String) => { err.append(e).append("\n"); () })
+      .orElse(Option.when(stdoutMode == StdMode.Forward) { (o: String) =>
+        sys.process.stderr.append(o).append("\n"); ()
+      })
       .getOrElse((_: String) => ())
-    val p: Process = Process(cmds).run(ProcessLogger(fout, ferr), connectInput = connectInput)
+
+    val proc: Process = Process(cmds).run(ProcessLogger(fout, ferr), connectInput = connectInput)
 
     timeout match {
       case Some(nSec) =>
-        val f = Future(blocking(p.exitValue()))
+        val f = Future(blocking(proc.exitValue()))
         try {
           val retcode = Await.result(f, duration.Duration(nSec, "sec"))
           val (stdout, stderr) = getStds
           (retcode, stdout, stderr)
         } catch {
           case _: TimeoutException =>
-            p.destroy()
+            proc.destroy()
             throw CommandTimeout(s"Timeout exceeded (${nSec} seconds)", command, nSec)
         }
       case None =>
-        // blocks, and returns the exit code. Does NOT connect
-        // the standard in of the child job to the parent
-        val retcode = p.exitValue()
+        // blocks, and returns the exit code
+        val retcode = proc.exitValue()
         val (stdout, stderr) = getStds
         if (exceptionOnFailure && !allowedReturnCodes.contains(retcode)) {
           throw CommandExecError("Error running command", command, retcode, stdout, stderr)
@@ -73,12 +85,13 @@ object SysUtils {
   }
 
   /**
-    * Runs a child process using `/bin/sh -c`.
+    * Runs a child process using `/bin/sh -c` and captures stdout and stderr.
     * @param command the command to run
     * @param timeout seconds to wait before killing the process, or None to wait indefinitely
     * @param allowedReturnCodes Set of valid return codes; devaluts to {0}
     * @param exceptionOnFailure whether to throw an Exception if the command exists with a
     *                           non-zero return code
+    * @return tuple of (return code, stdout, stderr)
     */
   def execCommand(command: String,
                   timeout: Option[Int] = None,
@@ -86,14 +99,6 @@ object SysUtils {
                   exceptionOnFailure: Boolean = true): (Int, String, String) = {
     val (rc, stdout, stderr) = runCommand(command, timeout, allowedReturnCodes, exceptionOnFailure)
     (rc, stdout.get, stderr.get)
-  }
-
-  def execScript(script: Path,
-                 timeout: Option[Int] = None,
-                 allowedReturnCodes: Set[Int] = Set(0),
-                 exceptionOnFailure: Boolean = true): (Int, String, String) = {
-    // sh -c executes the commands in 'script' when the argument is a file
-    execCommand(script.toString, timeout, allowedReturnCodes, exceptionOnFailure)
   }
 
   /**

--- a/common/src/main/scala/dx/util/SysUtils.scala
+++ b/common/src/main/scala/dx/util/SysUtils.scala
@@ -24,36 +24,29 @@ case class CommandExecError(msg: String,
 case class CommandTimeout(msg: String, command: String, timeout: Int) extends Exception(msg)
 
 object SysUtils {
-  def execScript(script: Path,
+
+  def runCommand(command: String,
                  timeout: Option[Int] = None,
                  allowedReturnCodes: Set[Int] = Set(0),
-                 exceptionOnFailure: Boolean = true): (Int, String, String) = {
-    // sh -c executes the commands in 'script' when the argument is a file
-    execCommand(script.toString, timeout, allowedReturnCodes, exceptionOnFailure)
-  }
-
-  /**
-    * Runs a child process using `/bin/sh -c`.
-    * @param command the command to run
-    * @param timeout seconds to wait before killing the process, or None to wait indefinitely
-    * @param allowedReturnCodes Set of valid return codes; devaluts to {0}
-    * @param exceptionOnFailure whether to throw an Exception if the command exists with a
-    *                           non-zero return code
-    */
-  def execCommand(command: String,
-                  timeout: Option[Int] = None,
-                  allowedReturnCodes: Set[Int] = Set(0),
-                  exceptionOnFailure: Boolean = true): (Int, String, String) = {
+                 exceptionOnFailure: Boolean = true,
+                 connectInput: Boolean = false,
+                 captureStdout: Boolean = true,
+                 captureStderr: Boolean = true): (Int, Option[String], Option[String]) = {
     val cmds = Seq("/bin/sh", "-c", command)
-    val outStream = new StringBuilder()
-    val errStream = new StringBuilder()
-    def getStds: (String, String) = (outStream.toString, errStream.toString)
+    val outStream = Option.when(captureStdout)(new StringBuilder())
+    val errStream = Option.when(captureStderr)(new StringBuilder())
 
-    val procLogger = ProcessLogger(
-        (o: String) => { outStream.append(o).append("\n") },
-        (e: String) => { errStream.append(e).append("\n") }
-    )
-    val p: Process = Process(cmds).run(procLogger, connectInput = false)
+    def getStds: (Option[String], Option[String]) = {
+      (outStream.map(_.toString), errStream.map(_.toString))
+    }
+
+    val fout = outStream
+      .map(out => (o: String) => { out.append(o).append("\n"); () })
+      .getOrElse((_: String) => ())
+    val ferr = errStream
+      .map(err => (e: String) => { err.append(e).append("\n"); () })
+      .getOrElse((_: String) => ())
+    val p: Process = Process(cmds).run(ProcessLogger(fout, ferr), connectInput = connectInput)
 
     timeout match {
       case Some(nSec) =>
@@ -77,6 +70,30 @@ object SysUtils {
         }
         (retcode, stdout, stderr)
     }
+  }
+
+  /**
+    * Runs a child process using `/bin/sh -c`.
+    * @param command the command to run
+    * @param timeout seconds to wait before killing the process, or None to wait indefinitely
+    * @param allowedReturnCodes Set of valid return codes; devaluts to {0}
+    * @param exceptionOnFailure whether to throw an Exception if the command exists with a
+    *                           non-zero return code
+    */
+  def execCommand(command: String,
+                  timeout: Option[Int] = None,
+                  allowedReturnCodes: Set[Int] = Set(0),
+                  exceptionOnFailure: Boolean = true): (Int, String, String) = {
+    val (rc, stdout, stderr) = runCommand(command, timeout, allowedReturnCodes, exceptionOnFailure)
+    (rc, stdout.get, stderr.get)
+  }
+
+  def execScript(script: Path,
+                 timeout: Option[Int] = None,
+                 allowedReturnCodes: Set[Int] = Set(0),
+                 exceptionOnFailure: Boolean = true): (Int, String, String) = {
+    // sh -c executes the commands in 'script' when the argument is a file
+    execCommand(script.toString, timeout, allowedReturnCodes, exceptionOnFailure)
   }
 
   /**


### PR DESCRIPTION
* Adds `SysUtils.runCommand`, which exposes options for how to handle stdin/stdout/stderr.
* Adds `Paths.BaseEvalPaths.isLocal` attribute to differentiate local from remote paths.
* **Breaking** removes `SysUtils.execScript`. Use `runCommand` with the script path as the argument instead.