### PR TITLE
APPS-1098 Update fix directory path for `-separateOutputs`

### DIFF
--- a/protocols/RELEASE_NOTES.md
+++ b/protocols/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # dxFileAccessProtocols
 
+## in develop
+
+* minor fixes to DxFileAccessProtocol to ensure directory path starts with a forward slash
+
 ## 0.5.3 (2022-01-05)
 
 * Handles `ResourceNotFoundException` in `DxFileSource.exists`

--- a/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
+++ b/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
@@ -314,7 +314,7 @@ object DxFolderSource {
     if (folder.endsWith("/")) {
       folder
     } else {
-      s"${folder}/"
+      s"/${folder}/"
     }
   }
 

--- a/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
+++ b/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
@@ -310,13 +310,7 @@ case class DxFolderSource(dxProject: DxProject, dxFolder: String)(
 }
 
 object DxFolderSource {
-  def ensureEndsWithSlash(folder: String): String = {
-    if (folder.endsWith("/")) {
-      folder
-    } else {
-      s"/${folder}/"
-    }
-  }
+  def ensureEndsWithSlash(folder: String): String = s"/${folder.stripSuffix("/").stripPrefix("/")}/"
 
   def isDxFolderUri(uri: String): Boolean = {
     uri.startsWith(DxPath.DxUriPrefix) &&


### PR DESCRIPTION
(fix) DxFolderSource - ensure path starts with `/`