### PR TITLE
APPS-1098 Update fix directory path for `-separateOutputs`

### DIFF
--- a/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
+++ b/protocols/src/main/scala/dx/util/protocols/DxFileAccessProtocol.scala
@@ -311,9 +311,13 @@ case class DxFolderSource(dxProject: DxProject, dxFolder: String)(
 
 object DxFolderSource {
   def ensureEndsWithSlash(folder: String): String = {
-    folder match {
-      case "/" => folder
-      case _   => s"/${folder.stripSuffix("/").stripPrefix("/")}/"
+    folder.split(":") match {
+      case Array(head, tail) => s"${head}:${ensureEndsWithSlash(tail)}"
+      case Array(head) =>
+        head match {
+          case "/" => head
+          case _   => s"/${head.stripSuffix("/").stripPrefix("/")}/"
+        }
     }
 
   }

--- a/protocols/src/test/scala/dx/util/protocols/DxTest.scala
+++ b/protocols/src/test/scala/dx/util/protocols/DxTest.scala
@@ -107,5 +107,10 @@ class DxTest extends AnyFlatSpec with Matchers {
     DxFolderSource.ensureEndsWithSlash("this_folder/") shouldBe ("/this_folder/")
     DxFolderSource.ensureEndsWithSlash("/this_folder/") shouldBe ("/this_folder/")
     DxFolderSource.ensureEndsWithSlash("this_folder") shouldBe ("/this_folder/")
+    DxFolderSource
+      .ensureEndsWithSlash("project-qwertyuiopa:/this_folder") shouldBe ("project-qwertyuiopa:/this_folder/")
+    DxFolderSource
+      .ensureEndsWithSlash("project-qwertyuiopa:this_folder/") shouldBe ("project-qwertyuiopa:/this_folder/")
+    DxFolderSource.ensureEndsWithSlash("project-qwertyuiopa:/") shouldBe ("project-qwertyuiopa:/")
   }
 }


### PR DESCRIPTION
(fix) DxFolderSource - cover fully qualified folder path