### PR TITLE
Apps 2476 head job on demand attr

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # dxApi
 
 ## in develop
-...
+* adds `headJobOnDemand` attribute to jobNew call
 
 ## 0.13.8 (2023-07-21)
 * changes to allow compiling with `treeTurnaroundTimeThreshold` attribute which facilitates platform to send the email 

--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 dxApi {
-  version = "0.13.8-SNAPSHOT"
+  version = "0.13.9-SNAPSHOT"
 }
 
 #

--- a/api/src/main/scala/dx/api/DxApi.scala
+++ b/api/src/main/scala/dx/api/DxApi.scala
@@ -532,7 +532,8 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DxApi.default
                 dependsOn: Vector[DxExecution],
                 delayWorkspaceDestruction: Option[Boolean],
                 name: Option[String] = None,
-                details: Option[JsValue] = None): DxJob = {
+                details: Option[JsValue] = None,
+                headJobOnDemand: Boolean = false): DxJob = {
     val requiredFields = Map(
         "function" -> JsString(entryPoint),
         "input" -> inputs
@@ -567,7 +568,8 @@ case class DxApi(version: String = "1.0.0", dxEnv: DXEnvironment = DxApi.default
       case Some(d) => Map("details" -> d)
       case None    => Map.empty
     }
-    val request = requiredFields ++ instanceFields ++ dependsFields ++ dwdFields ++ nameFields ++ detailsFields
+    val headJobOnDemandField = if (headJobOnDemand) Map("headJobOnDemand" -> JsTrue) else Map.empty
+    val request = requiredFields ++ instanceFields ++ dependsFields ++ dwdFields ++ nameFields ++ detailsFields ++ headJobOnDemandField
     logger.traceLimited(s"subjob request=${JsObject(request).prettyPrint}")
     val response = jobNew(request)
     val id: String = response.fields.get("id") match {


### PR DESCRIPTION
Change to enable `headJobOnDemand` for the `job/new` API call. Hard to unit-test, so will be integration-tested in dxC PR.