### PR TITLE
COMPUTE-1237: Fix NullPointerException when failed to receive response

### DIFF
--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Fix `java.lang.NullPointerException` when could not receive response in `com.dnanexus.DXHTTPRequest`
+
 ## 0.13.11 (2025-03-24)
 
 * Support 429 Too Many Requests response code from platform to retry throttled requests.

--- a/api/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/api/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -461,7 +461,7 @@ public class DXHTTPRequest {
             attemptsWithThrottled++;
             // Retries due to 429 or 503 Service Unavailable and Retry-After do NOT count against the
             // allowed number of retries.
-            if (statusCode != 503 && statusCode != 429) {
+            if (statusCode == null || (statusCode != 503 && statusCode != 429)) {
                 attempts++;
             }
 

--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 dxApi {
-  version = "0.13.12-SNAPSHOT"
+  version = "0.13.12"
 }
 
 #

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ val yaml = project
 lazy val dependencies =
   new {
     val dxCommonVersion = "0.11.5"
-    val dxApiVersion = "0.13.11"
+    val dxApiVersion = "0.13.12"
     val typesafeVersion = "1.4.1"
     val sprayVersion = "1.3.6"
     val snakeyamlVersion = "2.3"


### PR DESCRIPTION
NullPointerException happened when I tried to [use dxApi in dxCompiler](https://github.com/dnanexus/dxCompiler/actions/runs/14089210499/job/39590964151). Seems that in case when there is some network error response is not initialized and `statusCode` is still `null` and can't be used with integer comparison.

with that fix compiler was built and tested w/o errors https://github.com/dnanexus/dxCompiler/actions/runs/14132661095
