### PR TITLE
COMPUTE-1237: Fix runtime error when incorrect application.conf was used for DXUserAgent

### DIFF
--- a/api/src/main/java/com/dnanexus/DXUserAgent.java
+++ b/api/src/main/java/com/dnanexus/DXUserAgent.java
@@ -24,7 +24,8 @@ import com.typesafe.config.ConfigFactory;
  * client.
  */
 class DXUserAgent {
-    private static final Config config = ConfigFactory.load();
+    // Load the configuration file from the classpath
+    private static final Config config = ConfigFactory.load(DXUserAgent.class.getClassLoader());
 
     /**
      * Returns a user-agent string.


### PR DESCRIPTION
[COMPUTE-1237](https://jira.internal.dnanexus.com/browse/COMPUTE-1237)

Without this fix nextaur-app had [runtime error](https://github.com/dnanexus/nextaur-app/actions/runs/14265505606) using dxApi package because it took incorrect `application.conf` instead of the one provided in `dxapi-{version}.jar` file.

New approach explicitly uses the class loader of the `DXUserAgent` class to load the configuration file.