### PR TITLE
Check sbt install

### DIFF
--- a/.github/workflows/actions/install-sbt/action.yml
+++ b/.github/workflows/actions/install-sbt/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         sudo apt-get update
         echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
-        curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x99E82A75642AC823" | sudo apt-key add
+        curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x99E82A75642AC823" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/sbt.gpg > /dev/null
         sudo apt-get update
         sudo apt-get install -y sbt
       shell: bash


### PR DESCRIPTION
I received [failed workflow](https://github.com/dnanexus/dxScala/actions/runs/14304452717/job/40089202633) because of issues with installing sbt. I think that this issue is temporary but there were also warnings of usage deprecated `apt-key add` that should be repleced to use `/etc/apt/trusted.gpg.d` instead of `/etc/apt/trusted.gpg`

<img width="1394" alt="image" src="https://github.com/user-attachments/assets/4d72c4fb-62a3-4b4c-850f-e69ee24bd488" />
