### PR TITLE
DEVEX-2604, DEVEX-2605: Fix choosing appropriate optimal instance instead of expensive GPU instance by default

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -50,9 +50,10 @@ If you want to make a change to dxScala, do the following:
    - For example, if the current release is `1.0.0` and the current snapshot version is `1.0.0-SNAPSHOT`, increment the snapshot version to `1.0.1-SNAPSHOT`.
 4. Make your changes. Test locally using `sbt test`.
 5. Update the release notes under the top-most header (which should be "Unreleased").
-6. If the current snapshot version only differs from the release version by a patch, and you added any new functionality (vs just fixing a bug), increment the minor version instead.
+6. Format changes with `sbt scalafmt`.
+7. If the current snapshot version only differs from the release version by a patch, and you added any new functionality (vs just fixing a bug), increment the minor version instead.
    - For example, when you first created the branch you set the version to `1.0.1-SNAPSHOT`, but then you realized you needed to add a new function to the public API, change the version to `1.1.0-SNAPSHOT`. 
-7. When you are done, create a pull request against the `develop` branch.
+8. When you are done, create a pull request against the `develop` branch.
 
 ### Building a local version for testing
 

--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix choosing appropriate optimal instance instead of expensive GPU instance by default
+
 ## 0.13.13 (2025-04-06)
 
 * Fix runtime error when incorrect `application.conf` was used for DXUserAgent

--- a/api/src/main/scala/dx/api/DxInstanceType.scala
+++ b/api/src/main/scala/dx/api/DxInstanceType.scala
@@ -99,7 +99,7 @@ object InstanceTypeRequest {
   * @param cpu number of CPU cores
   * @param gpu whether there is at least one GPU
   * @param os Vector of execution environments available, e.g.
-  *           [(Ubuntu, 16.04, 1), (Ubuntu, 20.04, 0)]
+  *           [(Ubuntu, 16.04, 1), (Ubuntu, 20.04, 0), (Ubuntu, 24.04, 0)]
   * @param diskType SSD or HDD
   * @param priceRank rank of this instance type's price vs the
   *                  other instance types in the database. Rank
@@ -302,21 +302,27 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
     * processing, launch jobs, etc.
     */
   lazy val defaultInstanceType: DxInstanceType = {
-    val (v2InstanceTypes, v1InstanceTypes) = instanceTypes.values
+    val eligibleInstances = instanceTypes.values
       .filter { instanceType =>
         !instanceType.name.contains("test") &&
-        instanceType.memoryMB >= InstanceTypeDB.MinMemory &&
-        instanceType.cpu >= InstanceTypeDB.MinCpu
+          instanceType.memoryMB >= InstanceTypeDB.MinMemory &&
+          instanceType.cpu >= InstanceTypeDB.MinCpu
       }
-      .partition(_.name.contains(DxInstanceType.Version2Suffix))
-    // prefer v2 instance types
-    selectMinimalInstanceType(v2InstanceTypes)
-      .orElse(selectMinimalInstanceType(v1InstanceTypes))
+
+    val (v2Instances, v1Instances) = eligibleInstances.partition(_.name.contains(DxInstanceType.Version2Suffix))
+
+    val preferredV2Instances = v2Instances.filterNot { instance =>
+      instance.gpu || instance.name.contains("fpga")
+    }
+
+    selectMinimalInstanceType(preferredV2Instances)           // a. Try preferred v2 (non-GPU/FPGA) first
+      .orElse(selectMinimalInstanceType(v1Instances))         // b. Then try v1
+      .orElse(selectMinimalInstanceType(v2Instances))         // c. As a last resort, consider all v2 (including GPU/FPGA)
       .getOrElse(
-          throw new Exception(
-              s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory} 
-                 |AND cpu >= ${InstanceTypeDB.MinCpu}""".stripMargin.replaceAll("\n", " ")
-          )
+        throw new Exception(
+          s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}
+             |AND cpu >= ${InstanceTypeDB.MinCpu}""".stripMargin.replaceAll("\n", " ")
+        )
       )
   }
 

--- a/api/src/main/scala/dx/api/DxInstanceType.scala
+++ b/api/src/main/scala/dx/api/DxInstanceType.scala
@@ -305,24 +305,25 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
     val eligibleInstances = instanceTypes.values
       .filter { instanceType =>
         !instanceType.name.contains("test") &&
-          instanceType.memoryMB >= InstanceTypeDB.MinMemory &&
-          instanceType.cpu >= InstanceTypeDB.MinCpu
+        instanceType.memoryMB >= InstanceTypeDB.MinMemory &&
+        instanceType.cpu >= InstanceTypeDB.MinCpu
       }
 
-    val (v2Instances, v1Instances) = eligibleInstances.partition(_.name.contains(DxInstanceType.Version2Suffix))
+    val (v2Instances, v1Instances) =
+      eligibleInstances.partition(_.name.contains(DxInstanceType.Version2Suffix))
 
     val preferredV2Instances = v2Instances.filterNot { instance =>
       instance.gpu || instance.name.contains("fpga")
     }
 
-    selectMinimalInstanceType(preferredV2Instances)           // a. Try preferred v2 (non-GPU/FPGA) first
-      .orElse(selectMinimalInstanceType(v1Instances))         // b. Then try v1
-      .orElse(selectMinimalInstanceType(v2Instances))         // c. As a last resort, consider all v2 (including GPU/FPGA)
+    selectMinimalInstanceType(preferredV2Instances) // a. Try preferred v2 (non-GPU/FPGA) first
+      .orElse(selectMinimalInstanceType(v1Instances)) // b. Then try v1
+      .orElse(selectMinimalInstanceType(v2Instances)) // c. As a last resort, consider all v2 (including GPU/FPGA)
       .getOrElse(
-        throw new Exception(
-          s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}
-             |AND cpu >= ${InstanceTypeDB.MinCpu}""".stripMargin.replaceAll("\n", " ")
-        )
+          throw new Exception(
+              s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}
+                 |AND cpu >= ${InstanceTypeDB.MinCpu}""".stripMargin.replaceAll("\n", " ")
+          )
       )
   }
 


### PR DESCRIPTION
This change is needed for dx compiler release in OCI Ashburn region where GPU instance (`oci:mem2_ssd1_GPU_v2_x24`) is taken by default because it has `v2` in name.

Also, this "v2" instance seems to be very rare because for several hours no instance was allocated.