### PR TITLE
COMPUTE-1727: Prefer v3 instance types over v2

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -54,7 +54,7 @@ If you want to make a change to dxScala, do the following:
  - Authentication requirement for some tests: Before running tests, authenticate to the staging environment and select a project `dx select dxCompiler_playground`.
    This is required because there are some tests that check files without implicitly specifying project, so this project has to be selected in background.
 5. Update the release notes under the top-most header (which should be "Unreleased").
-6. Format changes with `sbt scalafmt`.
+6. Format changes with `sbt scalafmtAll`.
 7. If the current snapshot version only differs from the release version by a patch, and you added any new functionality (vs just fixing a bug), increment the minor version instead.
    - For example, when you first created the branch you set the version to `1.0.1-SNAPSHOT`, but then you realized you needed to add a new function to the public API, change the version to `1.1.0-SNAPSHOT`. 
 8. When you are done, create a pull request against the `develop` branch.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -48,7 +48,11 @@ If you want to make a change to dxScala, do the following:
 2. Create a new branch with your changes. Name it something meaningful, like `APPS-123-download-bug`.
 3. If the current snapshot version matches the release version, increment the snapshot version.
    - For example, if the current release is `1.0.0` and the current snapshot version is `1.0.0-SNAPSHOT`, increment the snapshot version to `1.0.1-SNAPSHOT`.
-4. Make your changes. Test locally using `sbt test`.
+4. Make your changes. Test locally:
+ - Run `sbt test` to execute all tests
+ - Run `sbt "testOnly dx.api.<TestName>"` to test a specific file (replace `<TestName>` with your test class name)
+ - Authentication requirement for some tests: Before running tests, authenticate to the staging environment and select a project `dx select dxCompiler_playground`.
+   This is required because there are some tests that check files without implicitly specifying project, so this project has to be selected in background.
 5. Update the release notes under the top-most header (which should be "Unreleased").
 6. Format changes with `sbt scalafmt`.
 7. If the current snapshot version only differs from the release version by a patch, and you added any new functionality (vs just fixing a bug), increment the minor version instead.

--- a/api/RELEASE_NOTES.md
+++ b/api/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Prefer v3 instance types over v2
+
 ## 0.13.14 (2025-10-03)
 
 * Fix choosing appropriate optimal instance instead of expensive GPU instance by default

--- a/api/src/main/scala/dx/api/DxInstanceType.scala
+++ b/api/src/main/scala/dx/api/DxInstanceType.scala
@@ -218,11 +218,15 @@ case class DxInstanceType(name: String,
   }
 
   /**
-    * Compare instances based on version (v1 vs v2) -
-    * v2 instances are always better than v1 instances.
-    */
+   * Compare instances based on version (v1 vs v2 vs v3) -
+   * v3 instances are better than v2, which are better than v1 instances.
+   */
   def compareByType(that: DxInstanceType): Int = {
-    def typeVersion(name: String): Int = if (name contains DxInstanceType.Version2Suffix) 2 else 1
+    def typeVersion(name: String): Int = {
+      if (name.contains(DxInstanceType.Version3Suffix)) 3
+      else if (name.contains(DxInstanceType.Version2Suffix)) 2
+      else 1
+    }
     typeVersion(this.name).compareTo(typeVersion(that.name))
   }
 
@@ -237,7 +241,7 @@ case class DxInstanceType(name: String,
       if (resCmp != 0) {
         resCmp
       } else {
-        // all else being equal, choose v2 instances over v1
+        // all else being equal, choose v3/v2 instances over v1
         -compareByType(that)
       }
     }
@@ -254,7 +258,9 @@ object DxInstanceType extends DefaultJsonProtocol {
       DxInstanceType.apply
   )
   val Version2Suffix = "_v2"
-  val NewestVersion = "v2"
+  val Version3Suffix = "_v3"
+  val Version2NewestVersion = "v2"
+  val Version3NewestVersion = "v3"
   val CpuSuffixStart = "x"
   val InstanceNameSeparator = "_"
   private val MemoryNormFactor: Double = 1024.0
@@ -271,29 +277,38 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
   }
 
   private def newerVersionAvailable(instance: DxInstanceType): Boolean = {
-    if (instance.name contains DxInstanceType.Version2Suffix) true
-    else {
-      instanceTypes.contains(upgradeToLatestVersion(instance))
+    val latestVersion = upgradeToLatestVersion(instance)
+    if (latestVersion == instance.name) {
+      return false
     }
+    instanceTypes.contains(latestVersion)
   }
 
   private def upgradeToLatestVersion(instance: DxInstanceType): String = {
     val instanceNameElements = instance.name.split(DxInstanceType.InstanceNameSeparator).toVector
     val linkedElements = LinkedList.create(instanceNameElements)
     @tailrec
-    def insertVersion(linkedList: LinkedListInterface[String],
+    def insertVersion(version: String,
+                      linkedList: LinkedListInterface[String],
                       accu: Vector[String] = Vector.empty): Vector[String] = {
       linkedList match {
         case LinkedNil                                    => accu
         case l: LinkedList[String] if l.next == LinkedNil => l.value +: accu
         case l: LinkedList[String]
             if l.value.startsWith(DxInstanceType.CpuSuffixStart)
-              && l.next.value != DxInstanceType.NewestVersion =>
-          insertVersion(l.next, DxInstanceType.NewestVersion +: l.value +: accu)
-        case l: LinkedList[(String)] => insertVersion(l.next, l.value +: accu)
+              && l.next.value != DxInstanceType.Version2NewestVersion && l.next.value != DxInstanceType.Version3NewestVersion =>
+            insertVersion(version, l.next, version +: l.value +: accu)
+        case l: LinkedList[String] => insertVersion(version, l.next, l.value +: accu)
       }
     }
-    insertVersion(linkedElements).mkString("_")
+
+    val v3Name = insertVersion(DxInstanceType.Version3NewestVersion, linkedElements).mkString(DxInstanceType.InstanceNameSeparator)
+    if (instanceTypes.contains(v3Name)) {
+      v3Name
+    } else {
+      val v2Name = insertVersion(DxInstanceType.Version2NewestVersion, linkedElements).mkString(DxInstanceType.InstanceNameSeparator)
+      v2Name
+    }
   }
 
   /**
@@ -309,22 +324,36 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
         instanceType.cpu >= InstanceTypeDB.MinCpu
       }
 
-    // GPU and FPGA instances are expensive, so we try to avoid them
-    val nonGpuOrFpgaInstances = eligibleInstances.filterNot { instance =>
-      instance.gpu || instance.name.contains("fpga")
+    // Categorize instances by priority (higher priority = checked first)
+    val categorized = eligibleInstances.groupBy { instance =>
+      val name = instance.name.toLowerCase
+
+      val baseCategory = if (name.contains(DxInstanceType.Version3Suffix)) {
+        "v3"
+      } else if (name.contains(DxInstanceType.Version2Suffix)) {
+        "v2"
+      } else {
+        "v1"
+      }
+
+      if (name.contains("_gpu") || name.contains("_fpga")) {
+        s"${baseCategory}_gpu_fpga"
+      } else {
+        baseCategory
+      }
     }
 
-    val (v2Instances, v1Instances) =
-      nonGpuOrFpgaInstances.partition(_.name.contains(DxInstanceType.Version2Suffix))
+    val priorityOrder = Vector("v3", "v2", "v1","v3_gpu_fpga", "v2_gpu_fpga", "v1_gpu_fpga")
 
-    selectMinimalInstanceType(v2Instances) // a. Try preferred v2 (non-GPU/FPGA) first
-      .orElse(selectMinimalInstanceType(v1Instances)) // b. Then try v1
-      .orElse(selectMinimalInstanceType(eligibleInstances)) // c. As a last resort, consider all instances (including GPU/FPGA)
+    priorityOrder
+      .flatMap(category => categorized.get(category))
+      .flatMap(selectMinimalInstanceType)
+      .headOption
       .getOrElse(
-          throw new Exception(
-              s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}
-                 |AND cpu >= ${InstanceTypeDB.MinCpu}""".stripMargin.replaceAll("\n", " ")
-          )
+        throw new Exception(
+          s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}
+             |AND cpu >= ${InstanceTypeDB.MinCpu}""".stripMargin.replaceAll("\n", " ")
+        )
       )
   }
 
@@ -369,7 +398,7 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
       instance match {
         case None => return instance
         case Some(x)
-            if newerVersionAvailable(x) && !(x.name contains DxInstanceType.Version2Suffix) =>
+            if newerVersionAvailable(x) =>
           Logger.get.warning(
               s"""
                  |WARNING: an older version of the instance ${x.name} is specified.

--- a/api/src/main/scala/dx/api/DxInstanceType.scala
+++ b/api/src/main/scala/dx/api/DxInstanceType.scala
@@ -309,16 +309,17 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
         instanceType.cpu >= InstanceTypeDB.MinCpu
       }
 
-    val (v2Instances, v1Instances) =
-      eligibleInstances.partition(_.name.contains(DxInstanceType.Version2Suffix))
-
-    val preferredV2Instances = v2Instances.filterNot { instance =>
+    // GPU and FPGA instances are expensive, so we try to avoid them
+    val nonGpuOrFpgaInstances = eligibleInstances.filterNot { instance =>
       instance.gpu || instance.name.contains("fpga")
     }
 
-    selectMinimalInstanceType(preferredV2Instances) // a. Try preferred v2 (non-GPU/FPGA) first
+    val (v2Instances, v1Instances) =
+      nonGpuOrFpgaInstances.partition(_.name.contains(DxInstanceType.Version2Suffix))
+
+    selectMinimalInstanceType(v2Instances) // a. Try preferred v2 (non-GPU/FPGA) first
       .orElse(selectMinimalInstanceType(v1Instances)) // b. Then try v1
-      .orElse(selectMinimalInstanceType(v2Instances)) // c. As a last resort, consider all v2 (including GPU/FPGA)
+      .orElse(selectMinimalInstanceType(eligibleInstances)) // c. As a last resort, consider all instances (including GPU/FPGA)
       .getOrElse(
           throw new Exception(
               s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}

--- a/api/src/main/scala/dx/api/DxInstanceType.scala
+++ b/api/src/main/scala/dx/api/DxInstanceType.scala
@@ -220,9 +220,9 @@ case class DxInstanceType(name: String,
   }
 
   /**
-   * Compare instances based on version (v1 vs v2 vs v3 vs ...).
-   * Higher version number is always better.
-   */
+    * Compare instances based on version (v1 vs v2 vs v3 vs ...).
+    * Higher version number is always better.
+    */
   def compareByType(that: DxInstanceType): Int = {
     this.version.compareTo(that.version)
   }
@@ -263,12 +263,12 @@ object DxInstanceType extends DefaultJsonProtocol {
   private val DiskNormFactor: Double = 16.0
 
   /**
-   * Extracts the numeric version from the instance type name.
-   * Examples:
-   * "mem1_ssd1_x4" -> 1 (default)
-   * "mem1_ssd1_v2_x4" -> 2
-   * "mem1_ssd1_v3_x4" -> 3
-   */
+    * Extracts the numeric version from the instance type name.
+    * Examples:
+    * "mem1_ssd1_x4" -> 1 (default)
+    * "mem1_ssd1_v2_x4" -> 2
+    * "mem1_ssd1_v3_x4" -> 3
+    */
   def typeVersion(name: String): Int = {
     // Iterate over matches to find the last (most relevant) version suffix
     VersionRegex.findFirstMatchIn(name) match {
@@ -293,14 +293,14 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
   }
 
   /**
-   * Generates the name of the next highest version of the current instance name.
-   * If the current version is vN, it returns the string for v(N+1).
-   * E.g., "mem1_ssd1_x4" (v1) -> "mem1_ssd1_v2_x4"
-   * E.g., "mem1_ssd1_v2_x4" -> "mem1_ssd1_v3_x4"
-   *
-   * @param instance The DxInstanceType to upgrade.
-   * @return The potential name of the next version instance.
-   */
+    * Generates the name of the next highest version of the current instance name.
+    * If the current version is vN, it returns the string for v(N+1).
+    * E.g., "mem1_ssd1_x4" (v1) -> "mem1_ssd1_v2_x4"
+    * E.g., "mem1_ssd1_v2_x4" -> "mem1_ssd1_v3_x4"
+    *
+    * @param instance The DxInstanceType to upgrade.
+    * @return The potential name of the next version instance.
+    */
   private def getNextVersionName(instance: DxInstanceType): String = {
     val currentName = instance.name
     val currentVersion = DxInstanceType.typeVersion(currentName)
@@ -317,7 +317,8 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
         val parts = currentName.split(DxInstanceType.InstanceNameSeparator).toVector
         val (prefix, suffix) = parts.partition(!_.startsWith(DxInstanceType.CpuSuffixStart))
 
-        (prefix :+ nextVersionSuffix.stripPrefix("_") :+ suffix.head).mkString(DxInstanceType.InstanceNameSeparator)
+        (prefix :+ nextVersionSuffix.stripPrefix("_") :+ suffix.head)
+          .mkString(DxInstanceType.InstanceNameSeparator)
     }
   }
 
@@ -367,22 +368,25 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
       instance.gpu || instance.name.contains("fpga")
     }
 
-    val instancesToConsider = if (preferredInstances.nonEmpty) preferredInstances else eligibleInstances
+    val instancesToConsider =
+      if (preferredInstances.nonEmpty) preferredInstances else eligibleInstances
 
     // Sort by version first (descending), then by price/resources (ascending)
-    instancesToConsider.toVector.sortWith { (a, b) =>
-      val versionCmp = -a.compareByType(b)
-      if (versionCmp != 0) {
-        versionCmp < 0
-      } else {
-        a.compare(b) < 0
+    instancesToConsider.toVector
+      .sortWith { (a, b) =>
+        val versionCmp = -a.compareByType(b)
+        if (versionCmp != 0) {
+          versionCmp < 0
+        } else {
+          a.compare(b) < 0
+        }
       }
-    }.headOption
+      .headOption
       .getOrElse(
-        throw new Exception(
-          s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}
-             |AND cpu >= ${InstanceTypeDB.MinCpu}""".stripMargin.replaceAll("\n", " ")
-        )
+          throw new Exception(
+              s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}
+                 |AND cpu >= ${InstanceTypeDB.MinCpu}""".stripMargin.replaceAll("\n", " ")
+          )
       )
   }
 
@@ -426,8 +430,7 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
       val instance = instanceTypes.get(name)
       instance match {
         case None => return instance
-        case Some(x)
-            if newerVersionAvailable(x) =>
+        case Some(x) if newerVersionAvailable(x) =>
           Logger.get.warning(
               s"""
                  |WARNING: an older version of the instance ${x.name} is specified.

--- a/api/src/main/scala/dx/api/DxInstanceType.scala
+++ b/api/src/main/scala/dx/api/DxInstanceType.scala
@@ -27,7 +27,7 @@ price       comparative price
 package dx.api
 
 import dx.api
-import dx.util.{Enum, JsUtils, LinkedList, LinkedListInterface, LinkedNil, Logger}
+import dx.util.{Enum, JsUtils, Logger}
 import dx.util.Enum.enumFormat
 import spray.json.{RootJsonFormat, _}
 
@@ -70,7 +70,7 @@ case class InstanceTypeRequest(dxInstanceType: Option[String] = None,
                                os: Option[ExecutionEnvironment] = None,
                                optional: Boolean = false) {
   override def toString: String = {
-    s"""memory=(${minMemoryMB},${maxMemoryMB}) disk=(${minDiskGB},${maxDiskGB}) diskType=${diskType} 
+    s"""memory=(${minMemoryMB},${maxMemoryMB}) disk=(${minDiskGB},${maxDiskGB}) diskType=${diskType}
        |cores=(${minCpu},${maxCpu}) gpu=${gpu} os=${os} instancetype=${dxInstanceType}
        |optional=${optional}""".stripMargin.replaceAll("\n", " ")
   }
@@ -117,6 +117,8 @@ case class DxInstanceType(name: String,
                           diskType: Option[DiskType.DiskType] = None,
                           priceRank: Option[Int] = None)
     extends Ordered[DxInstanceType] {
+
+  @transient private lazy val version: Int = DxInstanceType.typeVersion(name)
 
   /**
     * Returns true if this instance type satisfies the requirements of `query`,
@@ -218,16 +220,11 @@ case class DxInstanceType(name: String,
   }
 
   /**
-   * Compare instances based on version (v1 vs v2 vs v3) -
-   * v3 instances are better than v2, which are better than v1 instances.
+   * Compare instances based on version (v1 vs v2 vs v3 vs ...).
+   * Higher version number is always better.
    */
   def compareByType(that: DxInstanceType): Int = {
-    def typeVersion(name: String): Int = {
-      if (name.contains(DxInstanceType.Version3Suffix)) 3
-      else if (name.contains(DxInstanceType.Version2Suffix)) 2
-      else 1
-    }
-    typeVersion(this.name).compareTo(typeVersion(that.name))
+    this.version.compareTo(that.version)
   }
 
   override def compare(that: DxInstanceType): Int = {
@@ -241,7 +238,7 @@ case class DxInstanceType(name: String,
       if (resCmp != 0) {
         resCmp
       } else {
-        // all else being equal, choose v3/v2 instances over v1
+        // all else being equal, choose newer versions (higher version number is better)
         -compareByType(that)
       }
     }
@@ -257,14 +254,33 @@ object DxInstanceType extends DefaultJsonProtocol {
   implicit val dxInstanceTypeFormat: RootJsonFormat[DxInstanceType] = jsonFormat8(
       DxInstanceType.apply
   )
-  val Version2Suffix = "_v2"
-  val Version3Suffix = "_v3"
-  val Version2NewestVersion = "v2"
-  val Version3NewestVersion = "v3"
+
+  // Use a regex to dynamically find any version suffix like '_vN'
+  val VersionRegex = "_v(\\d+)_".r
   val CpuSuffixStart = "x"
   val InstanceNameSeparator = "_"
   private val MemoryNormFactor: Double = 1024.0
   private val DiskNormFactor: Double = 16.0
+
+  /**
+   * Extracts the numeric version from the instance type name.
+   * Examples:
+   * "mem1_ssd1_x4" -> 1 (default)
+   * "mem1_ssd1_v2_x4" -> 2
+   * "mem1_ssd1_v3_x4" -> 3
+   */
+  def typeVersion(name: String): Int = {
+    // Iterate over matches to find the last (most relevant) version suffix
+    VersionRegex.findFirstMatchIn(name) match {
+      case Some(m) =>
+        try {
+          m.group(1).toInt
+        } catch {
+          case _: NumberFormatException => 1
+        }
+      case _ => 1
+    }
+  }
 }
 
 case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
@@ -276,38 +292,61 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
     instanceTypes.toVector.sortWith(_ < _).headOption
   }
 
-  private def newerVersionAvailable(instance: DxInstanceType): Boolean = {
-    val latestVersion = upgradeToLatestVersion(instance)
-    if (latestVersion == instance.name) {
-      return false
+  /**
+   * Generates the name of the next highest version of the current instance name.
+   * If the current version is vN, it returns the string for v(N+1).
+   * E.g., "mem1_ssd1_x4" (v1) -> "mem1_ssd1_v2_x4"
+   * E.g., "mem1_ssd1_v2_x4" -> "mem1_ssd1_v3_x4"
+   *
+   * @param instance The DxInstanceType to upgrade.
+   * @return The potential name of the next version instance.
+   */
+  private def getNextVersionName(instance: DxInstanceType): String = {
+    val currentName = instance.name
+    val currentVersion = DxInstanceType.typeVersion(currentName)
+    val nextVersion = currentVersion + 1
+    val nextVersionSuffix = s"_v${nextVersion}"
+
+    // Explicitly match the type for the regex result to access start/end
+    DxInstanceType.VersionRegex.findFirstMatchIn(currentName) match {
+      case Some(m: scala.util.matching.Regex.Match) =>
+        // Replace the existing version suffix with the next version suffix
+        currentName.substring(0, m.start) + nextVersionSuffix + currentName.substring(m.end)
+      case None =>
+        // Append the version suffix before the CPU part
+        val parts = currentName.split(DxInstanceType.InstanceNameSeparator).toVector
+        val (prefix, suffix) = parts.partition(!_.startsWith(DxInstanceType.CpuSuffixStart))
+
+        (prefix :+ nextVersionSuffix.stripPrefix("_") :+ suffix.head).mkString(DxInstanceType.InstanceNameSeparator)
     }
-    instanceTypes.contains(latestVersion)
+  }
+
+  private def newerVersionAvailable(instance: DxInstanceType): Boolean = {
+    val nextVersionName = getNextVersionName(instance)
+    instanceTypes.contains(nextVersionName)
   }
 
   private def upgradeToLatestVersion(instance: DxInstanceType): String = {
-    val instanceNameElements = instance.name.split(DxInstanceType.InstanceNameSeparator).toVector
-    val linkedElements = LinkedList.create(instanceNameElements)
     @tailrec
-    def insertVersion(version: String,
-                      linkedList: LinkedListInterface[String],
-                      accu: Vector[String] = Vector.empty): Vector[String] = {
-      linkedList match {
-        case LinkedNil                                    => accu
-        case l: LinkedList[String] if l.next == LinkedNil => l.value +: accu
-        case l: LinkedList[String]
-            if l.value.startsWith(DxInstanceType.CpuSuffixStart)
-              && l.next.value != DxInstanceType.Version2NewestVersion && l.next.value != DxInstanceType.Version3NewestVersion =>
-            insertVersion(version, l.next, version +: l.value +: accu)
-        case l: LinkedList[String] => insertVersion(version, l.next, l.value +: accu)
+    def findLatest(currentName: String): String = {
+      instanceTypes.get(currentName) match {
+        case None =>
+          currentName
+        case Some(tempInstance) =>
+          val nextVersionName = getNextVersionName(tempInstance)
+          if (nextVersionName != currentName && instanceTypes.contains(nextVersionName)) {
+            findLatest(nextVersionName)
+          } else {
+            currentName
+          }
       }
     }
 
-    val v3Name = insertVersion(DxInstanceType.Version3NewestVersion, linkedElements).mkString(DxInstanceType.InstanceNameSeparator)
-    if (instanceTypes.contains(v3Name)) {
-      v3Name
+    val nextVersionName = getNextVersionName(instance)
+    if (instanceTypes.contains(nextVersionName)) {
+      findLatest(nextVersionName)
     } else {
-      val v2Name = insertVersion(DxInstanceType.Version2NewestVersion, linkedElements).mkString(DxInstanceType.InstanceNameSeparator)
-      v2Name
+      instance.name
     }
   }
 
@@ -324,31 +363,21 @@ case class InstanceTypeDB(instanceTypes: Map[String, DxInstanceType]) {
         instanceType.cpu >= InstanceTypeDB.MinCpu
       }
 
-    // Categorize instances by priority (higher priority = checked first)
-    val categorized = eligibleInstances.groupBy { instance =>
-      val name = instance.name.toLowerCase
-
-      val baseCategory = if (name.contains(DxInstanceType.Version3Suffix)) {
-        "v3"
-      } else if (name.contains(DxInstanceType.Version2Suffix)) {
-        "v2"
-      } else {
-        "v1"
-      }
-
-      if (name.contains("_gpu") || name.contains("_fpga")) {
-        s"${baseCategory}_gpu_fpga"
-      } else {
-        baseCategory
-      }
+    val preferredInstances = eligibleInstances.filterNot { instance =>
+      instance.gpu || instance.name.contains("fpga")
     }
 
-    val priorityOrder = Vector("v3", "v2", "v1","v3_gpu_fpga", "v2_gpu_fpga", "v1_gpu_fpga")
+    val instancesToConsider = if (preferredInstances.nonEmpty) preferredInstances else eligibleInstances
 
-    priorityOrder
-      .flatMap(category => categorized.get(category))
-      .flatMap(selectMinimalInstanceType)
-      .headOption
+    // Sort by version first (descending), then by price/resources (ascending)
+    instancesToConsider.toVector.sortWith { (a, b) =>
+      val versionCmp = -a.compareByType(b)
+      if (versionCmp != 0) {
+        versionCmp < 0
+      } else {
+        a.compare(b) < 0
+      }
+    }.headOption
       .getOrElse(
         throw new Exception(
           s"""no instance types meet the minimal requirements memory >= ${InstanceTypeDB.MinMemory}

--- a/api/src/test/scala/dx/api/DxFileTest.scala
+++ b/api/src/test/scala/dx/api/DxFileTest.scala
@@ -20,6 +20,9 @@ class DxFileTest extends AnyFlatSpec with Matchers {
   private val FILE4: DxFile = dxApi.file("file-FqP0x4Q0bxKXBBXX5pjVYf3Q", Some(publicProject))
   private val FILE5: DxFile = dxApi.file("file-FqP0x4Q0bxKykykX5pVXB1YZ", Some(publicProject))
   private val FILE6: DxFile = dxApi.file("file-GPpggFQ0yzZjbYFz4Yk9pgzK", Some(testProject))
+  // Even though file is named "without project" it actually exists in testProject.
+  // In tests "without project" means that no project is specified when running search API requrest with dxApi.
+  // And to make these tests work you need to run in cli `dx select dxCompiler_playground` first.
   private val FILE6_WO_PROJ: DxFile = dxApi.file("file-GPpggFQ0yzZjbYFz4Yk9pgzK", None)
   private val FILE7_WO_PROJ: DxFile = dxApi.file("file-GPpgf8Q0yzZfqby2895jg56G", None)
 

--- a/api/src/test/scala/dx/api/InstanceTypeDBTest.scala
+++ b/api/src/test/scala/dx/api/InstanceTypeDBTest.scala
@@ -33,7 +33,7 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 }"""
 
   private val ExecutionEnvironments = Vector(
-    ExecutionEnvironment("ubuntu", "24.04", Vector("0"))
+      ExecutionEnvironment("ubuntu", "24.04", Vector("0"))
   )
 
   // Create an available instance list based on a hard coded list
@@ -65,7 +65,14 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     val cpu = name.split("_").last.drop(1).toInt
     val gpu = name.toLowerCase.contains("gpu")
 
-    DxInstanceType(name, memMB, diskGB, cpu, gpu, ExecutionEnvironments, Some(DiskType.SSD), Some(1))
+    DxInstanceType(name,
+                   memMB,
+                   diskGB,
+                   cpu,
+                   gpu,
+                   ExecutionEnvironments,
+                   Some(DiskType.SSD),
+                   Some(1))
   }
 
   private def createInstanceTypeDB(instances: DxInstanceType*): InstanceTypeDB = {
@@ -99,10 +106,10 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. select the minimal preferred v2 instance when available" in {
     // Setup a DB where v2 is better than v1
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_v2_x72", 144000, 1675), // v2: meets min requirements, but there is a better preferred v2
-      createTestInstance("mem1_ssd1_v2_x16", 32000, 372), // Preferred v2: meets min requirements
-      createTestInstance("mem1_ssd1_x2", 3766, 28), // V1
-      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235) // Non-preferred v2 (GPU)
+        createTestInstance("mem1_ssd1_v2_x72", 144000, 1675), // v2: meets min requirements, but there is a better preferred v2
+        createTestInstance("mem1_ssd1_v2_x16", 32000, 372), // Preferred v2: meets min requirements
+        createTestInstance("mem1_ssd1_x2", 3766, 28), // V1
+        createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235) // Non-preferred v2 (GPU)
     )
 
     db.defaultInstanceType.name shouldBe "mem1_ssd1_v2_x16"
@@ -111,9 +118,9 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. select the minimal v1 instance if no preferred v2 exists" in {
     // Setup a DB with only v1 and non-preferred v2 instances
     val db = createInstanceTypeDB(
-      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235), // Non-preferred v2 (GPU)
-      createTestInstance("mem1_ssd1_x2", 3766, 28), // V1
-      createTestInstance("v2_fpga_v2", 8192, 100) // Another Non-preferred v2 (FPGA): third lowest rank
+        createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235), // Non-preferred v2 (GPU)
+        createTestInstance("mem1_ssd1_x2", 3766, 28), // V1
+        createTestInstance("v2_fpga_v2", 8192, 100) // Another Non-preferred v2 (FPGA): third lowest rank
     )
 
     db.defaultInstanceType.name shouldBe "mem1_ssd1_x2"
@@ -122,8 +129,8 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. select the minimal non-preferred v2 instance if no preferred v2 or v1 exists" in {
     // Setup a DB with only non-preferred v2 instances
     val db = createInstanceTypeDB(
-      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235), // Non-preferred v2 (GPU)
-      createTestInstance("mem3_ssd2_fpga1_x24", 262144, 910) // Another Non-preferred v2 (FPGA)
+        createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235), // Non-preferred v2 (GPU)
+        createTestInstance("mem3_ssd2_fpga1_x24", 262144, 910) // Another Non-preferred v2 (FPGA)
     )
 
     db.defaultInstanceType.name shouldBe "mem2_ssd2_gpu1_v2_x4"
@@ -132,24 +139,26 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. throw an exception if no eligible instances meet minimums" in {
     // MinMemory = 3072, MinCpu = 2
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_x2", 3000, 28), // Fails min memory check
-      createTestInstance("mem2_hdd2_x1", 3750, 397), // Fails min cpu check
-      createTestInstance("test_instance_x2", 4000, 100) // Ignored instance name
+        createTestInstance("mem1_ssd1_x2", 3000, 28), // Fails min memory check
+        createTestInstance("mem2_hdd2_x1", 3750, 397), // Fails min cpu check
+        createTestInstance("test_instance_x2", 4000, 100) // Ignored instance name
     )
 
     // Expect exception
     val ex = intercept[Exception] {
       db.defaultInstanceType
     }
-    ex.getMessage should include("no instance types meet the minimal requirements memory >= 3072 AND cpu >= 2")
+    ex.getMessage should include(
+        "no instance types meet the minimal requirements memory >= 3072 AND cpu >= 2"
+    )
   }
 
   it should "defaultInstanceType. prefer v3 instance over v2" in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_x4", 3072, 80),
-      createTestInstance("mem1_ssd1_v2_x4", 3072, 80),
-      createTestInstance("mem1_ssd1_v3_x4", 3072, 80),
-      createTestInstance("mem1_ssd1_gpu1_x4", 3072, 80)
+        createTestInstance("mem1_ssd1_x4", 3072, 80),
+        createTestInstance("mem1_ssd1_v2_x4", 3072, 80),
+        createTestInstance("mem1_ssd1_v3_x4", 3072, 80),
+        createTestInstance("mem1_ssd1_gpu1_x4", 3072, 80)
     )
 
     db.defaultInstanceType.name shouldBe "mem1_ssd1_v3_x4"
@@ -158,8 +167,8 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. prefer gpu v3 instance if non-gpu v3, v2, or v1 exists" in {
     // All preferred (non-GPU/FPGA) instances are filtered out. Only GPU/FPGA remain.
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_gpu1_v3_x4", 3072, 80),
-      createTestInstance("mem1_ssd1_gpu1_v2_x4", 3072, 80)
+        createTestInstance("mem1_ssd1_gpu1_v3_x4", 3072, 80),
+        createTestInstance("mem1_ssd1_gpu1_v2_x4", 3072, 80)
     )
 
     db.defaultInstanceType.name shouldBe "mem1_ssd1_gpu1_v3_x4"
@@ -167,8 +176,8 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   it should "selectOptimal. work on large instances (JIRA-1258)" in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem3_ssd1_x32", 245751, 597),
-      createTestInstance("mem4_ssd1_x128", 1967522, 3573)
+        createTestInstance("mem3_ssd1_x32", 245751, 597),
+        createTestInstance("mem4_ssd1_x128", 1967522, 3573)
     )
 
     db.selectOptimal(
@@ -185,8 +194,8 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   it should "selectOptimal. prefer v2 instances over v1's" in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
-      createTestInstance("mem1_ssd1_x4", 8000, 80)
+        createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
+        createTestInstance("mem1_ssd1_x4", 8000, 80)
     )
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(4))) should matchPattern {
@@ -209,9 +218,9 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   it should "selectOptimal. respect requests for GPU instances" taggedAs EdgeTest in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
-      createTestInstance("mem1_ssd1_x4", 8000, 80),
-      createTestInstance("mem3_ssd1_gpu_x8", 30000, 100)
+        createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
+        createTestInstance("mem1_ssd1_x4", 8000, 80),
+        createTestInstance("mem3_ssd1_gpu_x8", 30000, 100)
     )
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(4), gpu = Some(true))) should matchPattern {
@@ -224,9 +233,9 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   it should "selectOptimal. prefer v3 over v2 over v1 when resources are equal" taggedAs EdgeTest in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_x4", 8000, 80),
-      createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
-      createTestInstance("mem1_ssd1_v3_x4", 8000, 80)
+        createTestInstance("mem1_ssd1_x4", 8000, 80),
+        createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
+        createTestInstance("mem1_ssd1_v3_x4", 8000, 80)
     )
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(4))) should matchPattern {
@@ -236,9 +245,9 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   it should "selectOptimal. GPU request prefers v3 GPU over v2 GPU" taggedAs EdgeTest in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem3_ssd1_gpu_v2_x8", 30000, 100),
-      createTestInstance("mem3_ssd1_gpu_v3_x8", 30000, 100),
-      createTestInstance("mem1_ssd1_v3_x4", 8000, 80)
+        createTestInstance("mem3_ssd1_gpu_v2_x8", 30000, 100),
+        createTestInstance("mem3_ssd1_gpu_v3_x8", 30000, 100),
+        createTestInstance("mem1_ssd1_v3_x4", 8000, 80)
     )
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(8), gpu = Some(true))) should matchPattern {
@@ -254,9 +263,9 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   it should "selectByName. issue a warning if requested a v1 instance by ID but v3 is available" in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_x16", 8000, 100),
-      createTestInstance("mem1_ssd1_v2_x16", 8000, 100),
-      createTestInstance("mem1_ssd1_v3_x16", 8000, 100)
+        createTestInstance("mem1_ssd1_x16", 8000, 100),
+        createTestInstance("mem1_ssd1_v2_x16", 8000, 100),
+        createTestInstance("mem1_ssd1_v3_x16", 8000, 100)
     )
 
     db.selectByName("mem1_ssd1_x16") should matchPattern {

--- a/api/src/test/scala/dx/api/InstanceTypeDBTest.scala
+++ b/api/src/test/scala/dx/api/InstanceTypeDBTest.scala
@@ -10,12 +10,7 @@ import spray.json._
 class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   // The original list is at:
-  // https://github.com/dnanexus/nucleus/blob/master/commons/instance_types/aws_instance_types.json
-  //
-  // The g2,i2,x1 instances have been removed, because they are not
-  // enabled for customers by default.  In addition, the PV (Paravirtual)
-  // instances have been removed, because they work only on Ubuntu
-  // 12.04.
+  // https://github.com/dnanexus/nucleus/blob/master/commons/instance_types/assets/aws_instance_types.json
   //
   // Removed the ssd2 instances, because they actually use EBS storage. A better
   // solution would be asking the platform for the available instances.
@@ -38,7 +33,7 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 }"""
 
   private val ExecutionEnvironments = Vector(
-      ExecutionEnvironment("ubuntu", "20.04", Vector("0"))
+    ExecutionEnvironment("ubuntu", "24.04", Vector("0"))
   )
 
   // Create an available instance list based on a hard coded list
@@ -66,6 +61,16 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   private val dxApi: DxApi = DxApi()(Logger.Quiet)
 
+  private def createTestInstance(name: String, memMB: Long, diskGB: Long,cpu: Int): DxInstanceType = {
+    val gpu = name.toLowerCase.contains("gpu")
+
+    DxInstanceType(name, memMB, diskGB, cpu, gpu, ExecutionEnvironments, Some(DiskType.SSD), Some(1))
+  }
+
+  private def createInstanceTypeDB(instances: DxInstanceType*): InstanceTypeDB = {
+    InstanceTypeDB(instances.map(instance => instance.name -> instance).toMap)
+  }
+
   it should "compare two instance types" in {
     // instances where all lhs resources are less than all rhs resources
     val c1 = testDb.compareByResources("mem1_ssd1_x2", "mem1_ssd1_x8")
@@ -90,30 +95,60 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     Logger.get.ignore(testDb.prettyFormat())
   }
 
-  it should "work on large instances (JIRA-1258)" in {
-    val db = InstanceTypeDB(
-        Map(
-            "mem3_ssd1_x32" -> DxInstanceType(
-                "mem3_ssd1_x32",
-                245751,
-                32,
-                597,
-                gpu = false,
-                ExecutionEnvironments,
-                Some(DiskType.SSD),
-                Some(1)
-            ),
-            "mem4_ssd1_x128" -> DxInstanceType(
-                "mem4_ssd1_x128",
-                1967522,
-                128,
-                3573,
-                gpu = false,
-                ExecutionEnvironments,
-                Some(DiskType.SSD),
-                Some(2)
-            )
-        )
+  it should "defaultInstanceType. select the minimal preferred v2 instance when available" in {
+    // Setup a DB where v2 is better than v1
+    val db = createInstanceTypeDB(
+      createTestInstance("mem1_ssd1_v2_x72", 144000, 1675, 72), // v2: meets min requirements, but there is a better preferred v2
+      createTestInstance("mem1_ssd1_v2_x16", 32000, 372, 16), // Preferred v2: meets min requirements
+      createTestInstance("mem1_ssd1_x2", 3766, 28, 2), // V1
+      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235, 4) // Non-preferred v2 (GPU)
+    )
+
+    db.defaultInstanceType.name shouldBe "mem1_ssd1_v2_x16"
+  }
+
+  it should "defaultInstanceType. select the minimal v1 instance if no preferred v2 exists" in {
+    // Setup a DB with only v1 and non-preferred v2 instances
+    val db = createInstanceTypeDB(
+      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235, 4), // Non-preferred v2 (GPU)
+      createTestInstance("mem1_ssd1_x2", 3766, 28, 2), // V1
+      createTestInstance("v2_fpga_v2", 8192, 100, 4) // Another Non-preferred v2 (FPGA): third lowest rank
+    )
+
+    db.defaultInstanceType.name shouldBe "mem1_ssd1_x2"
+  }
+
+  it should "defaultInstanceType. select the minimal non-preferred v2 instance if no preferred v2 or v1 exists" in {
+    // Setup a DB with only non-preferred v2 instances
+    val db = createInstanceTypeDB(
+      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235, 4), // Non-preferred v2 (GPU)
+      createTestInstance("mem3_ssd2_fpga1_x24", 262144, 910, 24) // Another Non-preferred v2 (FPGA)
+    )
+    println(db)
+
+    db.defaultInstanceType.name shouldBe "mem2_ssd2_gpu1_v2_x4"
+  }
+
+  it should "defaultInstanceType. throw an exception if no eligible instances meet minimums" in {
+    // MinMemory = 3072, MinCpu = 2
+    val db = createInstanceTypeDB(
+      createTestInstance("mem1_ssd1_x2", 3000, 28, 2), // Fails min memory check
+      createTestInstance("mem2_hdd2_x1", 3750, 397, 1), // Fails min cpu check
+      createTestInstance("test_instance", 4000, 100, 2) // Ignored instance name
+    )
+
+    // Expect exception
+    val ex = intercept[Exception] {
+      db.defaultInstanceType
+    }
+    ex.getMessage should include("no instance types meet the minimal requirements memory >= 3072 AND cpu >= 2")
+  }
+
+
+  it should "selectOptimal. work on large instances (JIRA-1258)" in {
+    val db = createInstanceTypeDB(
+      createTestInstance("mem3_ssd1_x32", 245751, 597, 32),
+      createTestInstance("mem4_ssd1_x128", 1967522, 3573, 128)
     )
 
     db.selectOptimal(
@@ -128,30 +163,10 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "prefer v2 instances over v1's" in {
-    val db = InstanceTypeDB(
-        Map(
-            "mem1_ssd1_v2_x4" -> DxInstanceType(
-                "mem1_ssd1_v2_x4",
-                8000,
-                80,
-                4,
-                gpu = false,
-                ExecutionEnvironments,
-                Some(DiskType.SSD),
-                Some(1)
-            ),
-            "mem1_ssd1_x4" -> DxInstanceType(
-                "mem1_ssd1_x4",
-                8000,
-                80,
-                4,
-                gpu = false,
-                ExecutionEnvironments,
-                Some(DiskType.SSD),
-                Some(1)
-            )
-        )
+  it should "selectOptimal. prefer v2 instances over v1's" in {
+    val db = createInstanceTypeDB(
+      createTestInstance("mem1_ssd1_v2_x4", 8000, 4, 80),
+      createTestInstance("mem1_ssd1_x4", 8000, 4, 80)
     )
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(4))) should matchPattern {
@@ -159,60 +174,26 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "upgrade to v2 when specifying system requirements with CPU" in {
+  it should "selectOptimal. upgrade to v2 when specifying system requirements with CPU" in {
     testDb.selectOptimal(InstanceTypeRequest(minCpu = Some(16))) should matchPattern {
       case Some(instanceType: DxInstanceType) if instanceType.name == "mem1_ssd1_v2_x16" =>
     }
   }
 
-  it should "keep v1 instance because v2 is not available in the DB" in {
+  it should "selectOptimal. keep v1 instance because v2 is not available in the DB" in {
     testDb
       .selectOptimal(InstanceTypeRequest(minCpu = Some(2), minMemoryMB = Some(7000))) should matchPattern {
       case Some(instanceType: DxInstanceType) if instanceType.name == "mem2_ssd1_x2" =>
     }
   }
 
-  it should "issue a warning if requested a v1 instance by ID but v2 is available" in {
-    testDb.selectByName("mem1_ssd1_x16") should matchPattern {
-      case Some(instanceType: DxInstanceType) if instanceType.name == "mem1_ssd1_x16" =>
-    }
-  }
-
-  it should "respect requests for GPU instances" taggedAs EdgeTest in {
-    val db = InstanceTypeDB(
-        Map(
-            "mem1_ssd1_v2_x4" -> DxInstanceType(
-                "mem1_ssd1_v2_x4",
-                8000,
-                80,
-                4,
-                gpu = false,
-                ExecutionEnvironments,
-                Some(DiskType.SSD),
-                Some(1)
-            ),
-            "mem1_ssd1_x4" -> DxInstanceType(
-                "mem1_ssd1_x4",
-                8000,
-                80,
-                4,
-                gpu = false,
-                ExecutionEnvironments,
-                Some(DiskType.SSD),
-                Some(1)
-            ),
-            "mem3_ssd1_gpu_x8" -> DxInstanceType(
-                "mem3_ssd1_gpu_x8",
-                30000,
-                100,
-                8,
-                gpu = true,
-                ExecutionEnvironments,
-                Some(DiskType.SSD),
-                Some(2)
-            )
-        )
+  it should "selectOptimal. respect requests for GPU instances" taggedAs EdgeTest in {
+    val db = createInstanceTypeDB(
+      createTestInstance("mem1_ssd1_v2_x4", 8000, 80, 4),
+      createTestInstance("mem1_ssd1_x4", 8000, 80, 4),
+      createTestInstance("mem3_ssd1_gpu_x8", 30000, 100, 8)
     )
+    println(db)
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(4), gpu = Some(true))) should matchPattern {
       case Some(instanceType: DxInstanceType) if instanceType.name == "mem3_ssd1_gpu_x8" =>
@@ -222,18 +203,24 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(8), gpu = Some(false))) shouldBe None
   }
 
+  it should "selectByName. issue a warning if requested a v1 instance by ID but v2 is available" in {
+    testDb.selectByName("mem1_ssd1_x16") should matchPattern {
+      case Some(instanceType: DxInstanceType) if instanceType.name == "mem1_ssd1_x16" =>
+    }
+  }
+
   it should "Query returns correct pricing models for org and user" taggedAs ApiTest in {
     // Instance type filter:
     // - Instance must support Ubuntu.
     // - Instance is not an FPGA instance.
     // - Instance does not have local HDD storage (those are older instance types).
     def instanceTypeFilter(instanceType: DxInstanceType): Boolean = {
-      instanceType.os.exists(_.release == "20.04") &&
-      !instanceType.diskType.contains(DiskType.HDD) &&
-      !instanceType.name.contains("fpga")
+      instanceType.os.exists(_.release == "24.04") &&
+        !instanceType.diskType.contains(DiskType.HDD) &&
+        !instanceType.name.contains("fpga")
     }
-    val userBilltoProject = dxApi.project("project-Fy9QqgQ0yzZbg9KXKP4Jz6Yq") // project name: dxCompiler_public_test
+    val userBilltoProject = dxApi.project("project-Fy9QqgQ0yzZbg9KXKP4Jz6Yq") // project name: dxCompiler_playground
     val db = InstanceTypeDB.create(userBilltoProject, instanceTypeFilter)
-    db.instanceTypes.size shouldBe 85
+    db.instanceTypes.size shouldBe 112
   }
 }

--- a/api/src/test/scala/dx/api/InstanceTypeDBTest.scala
+++ b/api/src/test/scala/dx/api/InstanceTypeDBTest.scala
@@ -124,7 +124,6 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
       createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235, 4), // Non-preferred v2 (GPU)
       createTestInstance("mem3_ssd2_fpga1_x24", 262144, 910, 24) // Another Non-preferred v2 (FPGA)
     )
-    println(db)
 
     db.defaultInstanceType.name shouldBe "mem2_ssd2_gpu1_v2_x4"
   }
@@ -193,7 +192,6 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
       createTestInstance("mem1_ssd1_x4", 8000, 80, 4),
       createTestInstance("mem3_ssd1_gpu_x8", 30000, 100, 8)
     )
-    println(db)
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(4), gpu = Some(true))) should matchPattern {
       case Some(instanceType: DxInstanceType) if instanceType.name == "mem3_ssd1_gpu_x8" =>
@@ -209,18 +207,36 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "Query returns correct pricing models for org and user" taggedAs ApiTest in {
-    // Instance type filter:
-    // - Instance must support Ubuntu.
-    // - Instance is not an FPGA instance.
-    // - Instance does not have local HDD storage (those are older instance types).
+  it should "AWS region. Query returns correct pricing models for org and user" taggedAs ApiTest in {
     def instanceTypeFilter(instanceType: DxInstanceType): Boolean = {
-      instanceType.os.exists(_.release == "24.04") &&
-        !instanceType.diskType.contains(DiskType.HDD) &&
-        !instanceType.name.contains("fpga")
+      instanceType.os.exists(_.release == "24.04")
     }
     val userBilltoProject = dxApi.project("project-Fy9QqgQ0yzZbg9KXKP4Jz6Yq") // project name: dxCompiler_playground
     val db = InstanceTypeDB.create(userBilltoProject, instanceTypeFilter)
-    db.instanceTypes.size shouldBe 112
+
+    db.instanceTypes.size shouldBe 133
+    db.defaultInstanceType.name shouldBe "mem1_ssd1_v2_x2"
+  }
+
+  it should "OCI region. Query returns correct pricing models for org and user" taggedAs ApiTest in {
+    def instanceTypeFilter(instanceType: DxInstanceType): Boolean = {
+      instanceType.os.exists(_.release == "24.04")
+    }
+    val userBilltoProject = dxApi.project("project-J1q0ZK963q4JXY2Qqv8xvX5J") // project name: App_Assets_Ashburn_Internal
+    val db = InstanceTypeDB.create(userBilltoProject, instanceTypeFilter)
+
+    db.instanceTypes.size shouldBe 37
+    db.defaultInstanceType.name shouldBe "oci:mem1_ssd1_v3i_x2"
+  }
+
+  it should "Azure region. Query returns correct pricing models for org and user" taggedAs ApiTest in {
+    def instanceTypeFilter(instanceType: DxInstanceType): Boolean = {
+      instanceType.os.exists(_.release == "24.04")
+    }
+    val userBilltoProject = dxApi.project("project-G24215Q9Vz71vv4b6Z3P6j84") // project name: App_Assets_Azure_Internal
+    val db = InstanceTypeDB.create(userBilltoProject, instanceTypeFilter)
+
+    db.instanceTypes.size shouldBe 22
+    db.defaultInstanceType.name shouldBe "azure:mem1_ssd1_x2"
   }
 }

--- a/api/src/test/scala/dx/api/InstanceTypeDBTest.scala
+++ b/api/src/test/scala/dx/api/InstanceTypeDBTest.scala
@@ -61,7 +61,8 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   private val dxApi: DxApi = DxApi()(Logger.Quiet)
 
-  private def createTestInstance(name: String, memMB: Long, diskGB: Long,cpu: Int): DxInstanceType = {
+  private def createTestInstance(name: String, memMB: Long, diskGB: Long): DxInstanceType = {
+    val cpu = name.split("_").last.drop(1).toInt
     val gpu = name.toLowerCase.contains("gpu")
 
     DxInstanceType(name, memMB, diskGB, cpu, gpu, ExecutionEnvironments, Some(DiskType.SSD), Some(1))
@@ -98,10 +99,10 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. select the minimal preferred v2 instance when available" in {
     // Setup a DB where v2 is better than v1
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_v2_x72", 144000, 1675, 72), // v2: meets min requirements, but there is a better preferred v2
-      createTestInstance("mem1_ssd1_v2_x16", 32000, 372, 16), // Preferred v2: meets min requirements
-      createTestInstance("mem1_ssd1_x2", 3766, 28, 2), // V1
-      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235, 4) // Non-preferred v2 (GPU)
+      createTestInstance("mem1_ssd1_v2_x72", 144000, 1675), // v2: meets min requirements, but there is a better preferred v2
+      createTestInstance("mem1_ssd1_v2_x16", 32000, 372), // Preferred v2: meets min requirements
+      createTestInstance("mem1_ssd1_x2", 3766, 28), // V1
+      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235) // Non-preferred v2 (GPU)
     )
 
     db.defaultInstanceType.name shouldBe "mem1_ssd1_v2_x16"
@@ -110,9 +111,9 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. select the minimal v1 instance if no preferred v2 exists" in {
     // Setup a DB with only v1 and non-preferred v2 instances
     val db = createInstanceTypeDB(
-      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235, 4), // Non-preferred v2 (GPU)
-      createTestInstance("mem1_ssd1_x2", 3766, 28, 2), // V1
-      createTestInstance("v2_fpga_v2", 8192, 100, 4) // Another Non-preferred v2 (FPGA): third lowest rank
+      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235), // Non-preferred v2 (GPU)
+      createTestInstance("mem1_ssd1_x2", 3766, 28), // V1
+      createTestInstance("v2_fpga_v2", 8192, 100) // Another Non-preferred v2 (FPGA): third lowest rank
     )
 
     db.defaultInstanceType.name shouldBe "mem1_ssd1_x2"
@@ -121,8 +122,8 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. select the minimal non-preferred v2 instance if no preferred v2 or v1 exists" in {
     // Setup a DB with only non-preferred v2 instances
     val db = createInstanceTypeDB(
-      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235, 4), // Non-preferred v2 (GPU)
-      createTestInstance("mem3_ssd2_fpga1_x24", 262144, 910, 24) // Another Non-preferred v2 (FPGA)
+      createTestInstance("mem2_ssd2_gpu1_v2_x4", 16384, 235), // Non-preferred v2 (GPU)
+      createTestInstance("mem3_ssd2_fpga1_x24", 262144, 910) // Another Non-preferred v2 (FPGA)
     )
 
     db.defaultInstanceType.name shouldBe "mem2_ssd2_gpu1_v2_x4"
@@ -131,9 +132,9 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
   it should "defaultInstanceType. throw an exception if no eligible instances meet minimums" in {
     // MinMemory = 3072, MinCpu = 2
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_x2", 3000, 28, 2), // Fails min memory check
-      createTestInstance("mem2_hdd2_x1", 3750, 397, 1), // Fails min cpu check
-      createTestInstance("test_instance", 4000, 100, 2) // Ignored instance name
+      createTestInstance("mem1_ssd1_x2", 3000, 28), // Fails min memory check
+      createTestInstance("mem2_hdd2_x1", 3750, 397), // Fails min cpu check
+      createTestInstance("test_instance_x2", 4000, 100) // Ignored instance name
     )
 
     // Expect exception
@@ -143,11 +144,31 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     ex.getMessage should include("no instance types meet the minimal requirements memory >= 3072 AND cpu >= 2")
   }
 
+  it should "defaultInstanceType. prefer v3 instance over v2" in {
+    val db = createInstanceTypeDB(
+      createTestInstance("mem1_ssd1_x4", 3072, 80),
+      createTestInstance("mem1_ssd1_v2_x4", 3072, 80),
+      createTestInstance("mem1_ssd1_v3_x4", 3072, 80),
+      createTestInstance("mem1_ssd1_gpu1_x4", 3072, 80)
+    )
+
+    db.defaultInstanceType.name shouldBe "mem1_ssd1_v3_x4"
+  }
+
+  it should "defaultInstanceType. prefer gpu v3 instance if non-gpu v3, v2, or v1 exists" in {
+    // All preferred (non-GPU/FPGA) instances are filtered out. Only GPU/FPGA remain.
+    val db = createInstanceTypeDB(
+      createTestInstance("mem1_ssd1_gpu1_v3_x4", 3072, 80),
+      createTestInstance("mem1_ssd1_gpu1_v2_x4", 3072, 80)
+    )
+
+    db.defaultInstanceType.name shouldBe "mem1_ssd1_gpu1_v3_x4"
+  }
 
   it should "selectOptimal. work on large instances (JIRA-1258)" in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem3_ssd1_x32", 245751, 597, 32),
-      createTestInstance("mem4_ssd1_x128", 1967522, 3573, 128)
+      createTestInstance("mem3_ssd1_x32", 245751, 597),
+      createTestInstance("mem4_ssd1_x128", 1967522, 3573)
     )
 
     db.selectOptimal(
@@ -164,8 +185,8 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   it should "selectOptimal. prefer v2 instances over v1's" in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_v2_x4", 8000, 4, 80),
-      createTestInstance("mem1_ssd1_x4", 8000, 4, 80)
+      createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
+      createTestInstance("mem1_ssd1_x4", 8000, 80)
     )
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(4))) should matchPattern {
@@ -188,9 +209,9 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
 
   it should "selectOptimal. respect requests for GPU instances" taggedAs EdgeTest in {
     val db = createInstanceTypeDB(
-      createTestInstance("mem1_ssd1_v2_x4", 8000, 80, 4),
-      createTestInstance("mem1_ssd1_x4", 8000, 80, 4),
-      createTestInstance("mem3_ssd1_gpu_x8", 30000, 100, 8)
+      createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
+      createTestInstance("mem1_ssd1_x4", 8000, 80),
+      createTestInstance("mem3_ssd1_gpu_x8", 30000, 100)
     )
 
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(4), gpu = Some(true))) should matchPattern {
@@ -201,8 +222,44 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     db.selectOptimal(InstanceTypeRequest(minCpu = Some(8), gpu = Some(false))) shouldBe None
   }
 
+  it should "selectOptimal. prefer v3 over v2 over v1 when resources are equal" taggedAs EdgeTest in {
+    val db = createInstanceTypeDB(
+      createTestInstance("mem1_ssd1_x4", 8000, 80),
+      createTestInstance("mem1_ssd1_v2_x4", 8000, 80),
+      createTestInstance("mem1_ssd1_v3_x4", 8000, 80)
+    )
+
+    db.selectOptimal(InstanceTypeRequest(minCpu = Some(4))) should matchPattern {
+      case Some(instanceType: DxInstanceType) if instanceType.name == "mem1_ssd1_v3_x4" =>
+    }
+  }
+
+  it should "selectOptimal. GPU request prefers v3 GPU over v2 GPU" taggedAs EdgeTest in {
+    val db = createInstanceTypeDB(
+      createTestInstance("mem3_ssd1_gpu_v2_x8", 30000, 100),
+      createTestInstance("mem3_ssd1_gpu_v3_x8", 30000, 100),
+      createTestInstance("mem1_ssd1_v3_x4", 8000, 80)
+    )
+
+    db.selectOptimal(InstanceTypeRequest(minCpu = Some(8), gpu = Some(true))) should matchPattern {
+      case Some(instanceType: DxInstanceType) if instanceType.name == "mem3_ssd1_gpu_v3_x8" =>
+    }
+  }
+
   it should "selectByName. issue a warning if requested a v1 instance by ID but v2 is available" in {
     testDb.selectByName("mem1_ssd1_x16") should matchPattern {
+      case Some(instanceType: DxInstanceType) if instanceType.name == "mem1_ssd1_x16" =>
+    }
+  }
+
+  it should "selectByName. issue a warning if requested a v1 instance by ID but v3 is available" in {
+    val db = createInstanceTypeDB(
+      createTestInstance("mem1_ssd1_x16", 8000, 100),
+      createTestInstance("mem1_ssd1_v2_x16", 8000, 100),
+      createTestInstance("mem1_ssd1_v3_x16", 8000, 100)
+    )
+
+    db.selectByName("mem1_ssd1_x16") should matchPattern {
       case Some(instanceType: DxInstanceType) if instanceType.name == "mem1_ssd1_x16" =>
     }
   }
@@ -215,7 +272,7 @@ class InstanceTypeDBTest extends AnyFlatSpec with Matchers {
     val db = InstanceTypeDB.create(userBilltoProject, instanceTypeFilter)
 
     db.instanceTypes.size shouldBe 133
-    db.defaultInstanceType.name shouldBe "mem1_ssd1_v2_x2"
+    db.defaultInstanceType.name shouldBe "mem1_ssd2_v3_x2"
   }
 
   it should "OCI region. Query returns correct pricing models for org and user" taggedAs ApiTest in {


### PR DESCRIPTION
Add support for new versions in instance types. Now dxApi correctly detects not only `v3` but next versions (`v4`, etc.) as well.